### PR TITLE
feat: lazy load jsonParser and yamlParser FlagFileParser

### DIFF
--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FileDataSourceParsing.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FileDataSourceParsing.java
@@ -73,17 +73,23 @@ abstract class FileDataSourceParsing {
 
   static abstract class FlagFileParser {
     static class JsonParserHolder {
-      static final FlagFileParser INSTANCE = new JsonFlagFileParser();
+      private static final JsonFlagFileParser INSTANCE = new JsonFlagFileParser();
+      static JsonFlagFileParser getInstance() {
+        return INSTANCE;
+      }
     }
     static class YamlParserHolder {
-      static final FlagFileParser INSTANCE = new YamlFlagFileParser();
+      private static final YamlFlagFileParser INSTANCE = new YamlFlagFileParser();
+      static YamlFlagFileParser getInstance() {
+        return INSTANCE;
+      }
     }
   
     public abstract FlagFileRep parse(InputStream input) throws FileDataException, IOException;
     
     public static FlagFileParser selectForContent(byte[] data) {
       Reader r = new InputStreamReader(new ByteArrayInputStream(data));
-      return detectJson(r) ? JsonParserHolder.INSTANCE : YamlParserHolder.INSTANCE;
+      return detectJson(r) ? JsonParserHolder.getInstance() : YamlParserHolder.getInstance();
     }
     
     private static boolean detectJson(Reader r) {


### PR DESCRIPTION
I want to be able to use the thin jar without the snakeyaml dependency, since I don't need to parse yaml files, just json files.

If I try that I get the following exception:

```
Cause: java.lang.ClassNotFoundException: org.yaml.snakeyaml.error.YAMLException
at java.base/java.net.URLClassLoader.findClass(URLClassLoader.java:476)
at sbt.internal.ManagedClassLoader.findClass(ManagedClassLoader.java:103)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:594)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:527)
at com.launchdarkly.sdk.server.integrations.FileDataSourceParsing$FlagFileParser.<clinit>(FileDataSourceParsing.java:76)
at com.launchdarkly.sdk.server.integrations.FileDataSourceImpl$DataLoader.load(FileDataSourceImpl.java:241)
at com.launchdarkly.sdk.server.integrations.FileDataSourceImpl.reload(FileDataSourceImpl.java:108)
at com.launchdarkly.sdk.server.integrations.FileDataSourceImpl.start(FileDataSourceImpl.java:92)
at com.launchdarkly.sdk.server.LDClient.<init>(LDClient.java:239)
```

This PR avoids loading the `YamlFlagFileParser` by using a holder class idiom for lazy initialization of a static field.

**Requirements**

- [ ] I have added test coverage for new or changed functionality
  - Existing tests still pass, but I don't see a way to add unit tests for this functionality. I published this library locally and tested it on my project successfully. 
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [ ] I have validated my changes against all supported platform versions

**Related issues**

n/a

**Describe the solution you've provided**

The solution is to lazy load the `YamlFlagFileParser` (and the `JsonFlagFileParser`) so they are only initialised if needed

**Describe alternatives you've considered**

n/a

**Additional context**

n/a
