### PR TITLE
ci: updating publish to use closeAndReleaseSonatypeStagingRepository

### DIFF
--- a/.github/actions/publish/publish.sh
+++ b/.github/actions/publish/publish.sh
@@ -14,7 +14,7 @@ else
         }
     else
         echo "RELEASE"
-        ${WORKSPACE_PATH}/gradlew publishToSonatype closeAndReleaseRepository -p ${WORKSPACE_PATH} -Psigning.keyId="${SIGNING_KEY_ID}" -Psigning.password="${SIGNING_KEY_PASSPHRASE}" -Psigning.secretKeyRingFile="${SIGNING_SECRET_KEY_RING_FILE}" -PsonatypeUsername="${SONATYPE_USER_NAME}" -PsonatypePassword="${SONATYPE_PASSWORD}" || {
+        ${WORKSPACE_PATH}/gradlew publishToSonatype closeAndReleaseSonatypeStagingRepository -p ${WORKSPACE_PATH} -Psigning.keyId="${SIGNING_KEY_ID}" -Psigning.password="${SIGNING_KEY_PASSPHRASE}" -Psigning.secretKeyRingFile="${SIGNING_SECRET_KEY_RING_FILE}" -PsonatypeUsername="${SONATYPE_USER_NAME}" -PsonatypePassword="${SONATYPE_PASSWORD}" || {
             echo "Gradle publish/release failed" >&2
             exit 1
         }

--- a/lib/sdk/server/build.gradle
+++ b/lib/sdk/server/build.gradle
@@ -22,7 +22,6 @@ plugins {
     id "com.github.johnrengelman.shadow" version "7.1.2"
     id "maven-publish"
     id "io.github.gradle-nexus.publish-plugin" version "1.3.0" apply false
-    id "io.codearte.nexus-staging" version "0.21.2"
     id "org.ajoberstar.git-publish" version "2.1.3"
     id "idea"
 }
@@ -544,11 +543,6 @@ idea {
         downloadJavadoc = true
         downloadSources = true
     }
-}
-
-nexusStaging {
-    packageGroup = "com.launchdarkly"
-    numberOfRetries = 40 // we've seen extremely long delays in closing repositories
 }
 
 def pomConfig = {

--- a/lib/shared/common/build.gradle.kts
+++ b/lib/shared/common/build.gradle.kts
@@ -80,11 +80,6 @@ publishing {
     }
 }
 
-nexusStaging {
-    packageGroup = ProjectValues.groupId
-    numberOfRetries = 40 // we've seen extremely long delays in closing repositories
-}
-
 nexusPublishing {
     clientTimeout.set(Duration.ofMinutes(2)) // we've seen extremely long delays in creating repositories
     repositories {

--- a/lib/shared/common/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/lib/shared/common/buildSrc/src/main/kotlin/Dependencies.kt
@@ -10,7 +10,6 @@ object Versions {
 
 object PluginVersions {
     const val nexusPublish = "1.3.0"
-    const val nexusStaging = "0.30.0"
 }
 
 object Libs {
@@ -61,7 +60,6 @@ object Libs {
     )
 
     val javaExtGradlePlugins = mapOf(
-        "io.github.gradle-nexus.publish-plugin" to PluginVersions.nexusPublish,
-        "io.codearte.nexus-staging" to PluginVersions.nexusStaging
+        "io.github.gradle-nexus.publish-plugin" to PluginVersions.nexusPublish
     )
 }

--- a/lib/shared/internal/build.gradle.kts
+++ b/lib/shared/internal/build.gradle.kts
@@ -74,11 +74,6 @@ publishing {
     }
 }
 
-nexusStaging {
-    packageGroup = ProjectValues.groupId
-    numberOfRetries = 40 // we've seen extremely long delays in closing repositories
-}
-
 nexusPublishing {
     clientTimeout.set(Duration.ofMinutes(2)) // we've seen extremely long delays in creating repositories
     repositories {

--- a/lib/shared/internal/buildSrc/src/main/kotlin/Dependencies.kt
+++ b/lib/shared/internal/buildSrc/src/main/kotlin/Dependencies.kt
@@ -12,7 +12,6 @@ object Versions {
 
 object PluginVersions {
     const val nexusPublish = "1.3.0"
-    const val nexusStaging = "0.30.0"
 }
 
 object Libs {
@@ -52,7 +51,6 @@ object Libs {
     )
 
     val javaExtGradlePlugins = mapOf(
-        "io.github.gradle-nexus.publish-plugin" to PluginVersions.nexusPublish,
-        "io.codearte.nexus-staging" to PluginVersions.nexusStaging
+        "io.github.gradle-nexus.publish-plugin" to PluginVersions.nexusPublish
     )
 }


### PR DESCRIPTION
**Related issues**

SC-245941

**Describe the solution you've provided**

At some point in the past, a community nexus staging plugin was used which had task 'closeAndReleaseRepository'.  This appears to no longer successfully close staging repositories as it once did, so switching to 'closeAndReleaseSonatypeStagingRepository' which is a task supported by the official nexus plugin.