### PR TITLE
chore: Convert JSON LDValue into the AiConfig Object

### DIFF
--- a/.github/workflows/java-server-sdk-ai.yml
+++ b/.github/workflows/java-server-sdk-ai.yml
@@ -1,0 +1,23 @@
+name: java-server-sdk-ai
+
+on:
+  push:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md' #Do not need to run CI for markdown changes.
+  pull_request:
+    branches: [main, 'feat/**']
+    paths-ignore:
+      - '**.md'
+
+jobs:
+  build-test-java-server-sdk-ai:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - name: Shared CI Steps
+        uses: ./.github/actions/ci
+        with:
+          workspace_path: 'lib/sdk/server-ai'
+          java_version: 8

--- a/.github/workflows/java-server-sdk-ai.yml
+++ b/.github/workflows/java-server-sdk-ai.yml
@@ -6,7 +6,7 @@ on:
     paths-ignore:
       - '**.md' #Do not need to run CI for markdown changes.
   pull_request:
-    branches: [main, 'feat/**']
+    branches: [main, 'feat/**', 'lc/**']
     paths-ignore:
       - '**.md'
 

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -60,7 +60,7 @@ public final class LDAiClient implements LDAiClientInterface {
         // Verify the whole value is a JSON object
         if (!checkValueWithFailureLogging(value, LDValueType.OBJECT, logger,
                 "Input to parseAiConfig must be a JSON object")) {
-            return new AiConfig(enabled, null, null, null, null);
+            return AiConfig.builder().enabled(enabled).build();
         }
 
         // Convert the _meta JSON object into Meta
@@ -68,7 +68,7 @@ public final class LDAiClient implements LDAiClientInterface {
         if (!checkValueWithFailureLogging(valueMeta, LDValueType.OBJECT, logger, "_ldMeta must be a JSON object")) {
             // Q: If we can't read _meta, enabled by spec would be defaulted to false. Does
             // it even matter the rest of the values?
-            return new AiConfig(enabled, null, null, null, null);
+            return AiConfig.builder().enabled(enabled).build();
         }
 
         // The booleanValue will get false if that value is something that we are not expecting
@@ -80,9 +80,10 @@ public final class LDAiClient implements LDAiClientInterface {
                 "variationKey should be a string")) {
             String variationKey = valueMeta.get("variationKey").stringValue();
 
-            meta = new Meta(
-                variationKey,
-                Optional.of(valueMeta.get("version").intValue()));
+            meta = Meta.builder()
+                .variationKey(variationKey)
+                .version(Optional.of(valueMeta.get("version").intValue()))
+                .build();
         }
 
         // Convert the optional model from an JSON object of with parameters and custom
@@ -119,7 +120,11 @@ public final class LDAiClient implements LDAiClientInterface {
                     }
                 }
 
-                model = new Model(modelName, parameters, custom);
+                model = Model.builder()
+                    .name(modelName)
+                    .parameters(parameters)
+                    .custom(custom)
+                    .build();
             }
         }
 
@@ -147,11 +152,17 @@ public final class LDAiClient implements LDAiClientInterface {
                     "provider name must be a String")) {
                 String providerName = valueProvider.get("name").stringValue();
 
-                provider = new Provider(providerName);
+                provider = Provider.builder().name(providerName).build();
             }
         }
 
-        return new AiConfig(enabled, meta, model, messages, provider);
+        return AiConfig.builder()
+            .enabled(enabled)
+            .meta(meta)
+            .model(model)
+            .messages(messages)
+            .provider(provider)
+            .build();
     }
 
     protected boolean checkValueWithFailureLogging(LDValue ldValue, LDValueType expectedType, LDLogger logger,

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -84,12 +84,8 @@ public final class LDAiClient implements LDAiClientInterface {
             }
 
             List<Message> messages = new ArrayList<Message>();
-            for (LDValue valueMessage : valueMessages.values()) {
-                if (valueMessage == LDValue.ofNull() || valueMessage.getType() != LDValueType.OBJECT) {
-                    throw new AiConfigParseException("individual message must be a JSON object");
-                }
-
-                Message message = new Message(ldValueNullCheck(valueMessage.get("content")).stringValue(), Role.valueOf(valueMessage.get("role").stringValue().toUpperCase()));
+            valueMessages.valuesAs(new Message.MessageConverter());
+            for (Message message : valueMessages.valuesAs(new Message.MessageConverter())) {
                 messages.add(message);
             }
             result.setMessages(messages);

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -23,7 +23,7 @@ import com.launchdarkly.sdk.server.ai.interfaces.LDAiClientInterface;
  * and generating events specific to usage of the AI Config when interacting
  * with model providers.
  */
-public class LDAiClient implements LDAiClientInterface {
+public final class LDAiClient implements LDAiClientInterface {
     private LDClientInterface client;
     private LDLogger logger;
 
@@ -89,11 +89,7 @@ public class LDAiClient implements LDAiClientInterface {
                     throw new AiConfigParseException("individual message must be a JSON object");
                 }
 
-                Message message = new Message();
-                message.setContent(ldValueNullCheck(valueMessage.get("content")).stringValue());
-                // TODO: For absolute safety, we need to check this is one out of the three
-                // possible enum
-                message.setRole(Role.valueOf(valueMessage.get("role").stringValue().toUpperCase()));
+                Message message = new Message(ldValueNullCheck(valueMessage.get("content")).stringValue(), Role.valueOf(valueMessage.get("role").stringValue().toUpperCase()));
                 messages.add(message);
             }
             result.setMessages(messages);
@@ -150,8 +146,7 @@ public class LDAiClient implements LDAiClientInterface {
                     throw new AiConfigParseException("non-null provider must be a JSON object");
                 }
 
-                Provider provider = new Provider();
-                provider.setName(ldValueNullCheck(valueProvider.get("name")).stringValue());
+                Provider provider = new Provider(ldValueNullCheck(valueProvider.get("name")).stringValue());
                 result.setProvider(provider);
             } else {
                 // Provider is optional - we can just set null and proceed

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -71,8 +71,7 @@ public final class LDAiClient implements LDAiClientInterface {
             return new AiConfig(enabled, null, null, null, null);
         }
 
-        // The booleanValue will get false if that value something that we are not
-        // expecting, which is good
+        // The booleanValue will get false if that value is something that we are not expecting
         enabled = valueMeta.get("enabled").booleanValue();
 
         Meta meta = null;
@@ -140,17 +139,17 @@ public final class LDAiClient implements LDAiClientInterface {
 
         // Convert the optional provider from an JSON object of with name into Provider
         LDValue valueProvider = value.get("provider");
-        String providerName = null;
+        Provider provider = null;
 
         if (checkValueWithFailureLogging(valueProvider, LDValueType.OBJECT, logger,
                 "non-null provider must be a JSON object")) {
             if (checkValueWithFailureLogging(valueProvider.get("name"), LDValueType.STRING, logger,
                     "provider name must be a String")) {
-                providerName = valueProvider.get("name").stringValue();
+                String providerName = valueProvider.get("name").stringValue();
+
+                provider = new Provider(providerName);
             }
         }
-
-        Provider provider = new Provider(providerName);
 
         return new AiConfig(enabled, meta, model, messages, provider);
     }
@@ -158,17 +157,12 @@ public final class LDAiClient implements LDAiClientInterface {
     protected boolean checkValueWithFailureLogging(LDValue ldValue, LDValueType expectedType, LDLogger logger,
             String message) {
         if (ldValue.getType() != expectedType) {
+            // TODO: In the next PR, make this required with some sort of default logger
             if (logger != null) {
                 logger.error(message);
             }
             return false;
         }
         return true;
-    }
-
-    class AiConfigParseException extends Exception {
-        AiConfigParseException(String exceptionMessage) {
-            super(exceptionMessage);
-        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -1,12 +1,27 @@
 package com.launchdarkly.sdk.server.ai;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Optional;
+
 import com.launchdarkly.logging.LDLogger;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
+import com.launchdarkly.sdk.LDValue;
+import com.launchdarkly.sdk.LDValueType;
+import com.launchdarkly.sdk.server.ai.datamodel.AiConfig;
+import com.launchdarkly.sdk.server.ai.datamodel.Message;
+import com.launchdarkly.sdk.server.ai.datamodel.Meta;
+import com.launchdarkly.sdk.server.ai.datamodel.Model;
+import com.launchdarkly.sdk.server.ai.datamodel.Provider;
+import com.launchdarkly.sdk.server.ai.datamodel.Role;
 import com.launchdarkly.sdk.server.ai.interfaces.LDAiClientInterface;
 
 /**
- * The LaunchDarkly AI client. The client is capable of retrieving AI Configs from LaunchDarkly,
- * and generating events specific to usage of the AI Config when interacting with model providers.
+ * The LaunchDarkly AI client. The client is capable of retrieving AI Configs
+ * from LaunchDarkly,
+ * and generating events specific to usage of the AI Config when interacting
+ * with model providers.
  */
 public class LDAiClient implements LDAiClientInterface {
     private LDClientInterface client;
@@ -15,14 +30,151 @@ public class LDAiClient implements LDAiClientInterface {
     /**
      * Creates a {@link LDAiClient}
      * 
-     * @param client LaunchDarkly Java Server SDK 
+     * @param client LaunchDarkly Java Server SDK
      */
     public LDAiClient(LDClientInterface client) {
-        if(client == null) {
-            //Error
+        if (client == null) {
+            // Error
         } else {
             this.client = client;
             this.logger = client.getLogger();
+        }
+    }
+
+    /**
+     * Method to convert the JSON variable into the AiConfig object
+     *
+     * Currently, I am doing this in a mutable way, just to verify the logic convert
+     * LDValue into AiConfig.
+     * It is possible we need a builder to create immutable version of this for ease
+     * of use in a later PR.
+     *
+     * @param value
+     * @param key
+     */
+    protected AiConfig parseAiConfig(LDValue value, String key) {
+        AiConfig result = new AiConfig();
+
+        try {
+            // Verify the whole value is a JSON object
+            if (value == null || value.getType() != LDValueType.OBJECT) {
+                throw new AiConfigParseException("Input to parseAiConfig must be a JSON object");
+            }
+
+            // Convert the _meta JSON object into Meta
+            LDValue valueMeta = value.get("_ldMeta");
+            if (valueMeta == LDValue.ofNull() || valueMeta.getType() != LDValueType.OBJECT) {
+                throw new AiConfigParseException("_ldMeta must be a JSON object");
+            }
+
+            Meta meta = new Meta();
+            // TODO: Do we expect customer calling this to build default value?
+            // If we do, then some of the values would be null
+            meta.setEnabled(ldValueNullCheck(valueMeta.get("enabled")).booleanValue());
+            meta.setVariationKey(ldValueNullCheck(valueMeta.get("variationKey")).stringValue());
+            Optional<Integer> version = Optional.of(valueMeta.get("version").intValue());
+            meta.setVersion(version);
+            result.setMeta(meta);
+
+            // Convert the optional messages from an JSON array of JSON objects into Message
+            // Q: Does it even make sense to have 0 messages?
+            LDValue valueMessages = value.get("messages");
+            if (valueMeta == LDValue.ofNull() || valueMessages.getType() != LDValueType.ARRAY) {
+                throw new AiConfigParseException("messages must be a JSON array");
+            }
+
+            List<Message> messages = new ArrayList<Message>();
+            for (LDValue valueMessage : valueMessages.values()) {
+                if (valueMessage == LDValue.ofNull() || valueMessage.getType() != LDValueType.OBJECT) {
+                    throw new AiConfigParseException("individual message must be a JSON object");
+                }
+
+                Message message = new Message();
+                message.setContent(ldValueNullCheck(valueMessage.get("content")).stringValue());
+                // TODO: For absolute safety, we need to check this is one out of the three
+                // possible enum
+                message.setRole(Role.valueOf(valueMessage.get("role").stringValue().toUpperCase()));
+                messages.add(message);
+            }
+            result.setMessages(messages);
+
+            // Convert the optional model from an JSON object of with parameters and custom
+            // into Model
+            LDValue valueModel = value.get("model");
+            if (valueModel == LDValue.ofNull() || valueModel.getType() != LDValueType.OBJECT) {
+                throw new AiConfigParseException("model must be a JSON object");
+            }
+
+            Model model = new Model();
+            model.setName(ldValueNullCheck(valueModel.get("name")).stringValue());
+
+            LDValue valueParameters = valueModel.get("parameters");
+            if (valueParameters.getType() != LDValueType.NULL) {
+                if (valueParameters.getType() != LDValueType.OBJECT) {
+                    throw new AiConfigParseException("non-null parameters must be a JSON object");
+                }
+
+                HashMap<String, LDValue> parameters = new HashMap<>();
+                for (String k : valueParameters.keys()) {
+                    parameters.put(k, valueParameters.get(k));
+                }
+                model.setParameters(parameters);
+            } else {
+                // Parameters is optional - so we can just set null and proceed
+
+                // TODO: Mustash validation somewhere
+                model.setParameters(null);
+            }
+
+            LDValue valueCustom = valueModel.get("custom");
+            if (valueCustom.getType() != LDValueType.NULL) {
+                if (valueCustom.getType() != LDValueType.OBJECT) {
+                    throw new AiConfigParseException("non-null custom must be a JSON object");
+                }
+
+                HashMap<String, LDValue> custom = new HashMap<>();
+                for (String k : valueCustom.keys()) {
+                    custom.put(k, valueCustom.get(k));
+                }
+                model.setCustom(custom);
+            } else {
+                // Custom is optional - we can just set null and proceed
+                model.setCustom(null);
+            }
+            result.setModel(model);
+
+            // Convert the optional provider from an JSON object of with name into Provider
+            LDValue valueProvider = value.get("provider");
+            if (valueProvider.getType() != LDValueType.NULL) {
+                if (valueProvider.getType() != LDValueType.OBJECT) {
+                    throw new AiConfigParseException("non-null provider must be a JSON object");
+                }
+
+                Provider provider = new Provider();
+                provider.setName(ldValueNullCheck(valueProvider.get("name")).stringValue());
+                result.setProvider(provider);
+            } else {
+                // Provider is optional - we can just set null and proceed
+                result.setProvider(null);
+            }
+        } catch (AiConfigParseException e) {
+            // logger.error(e.getMessage());
+            return null;
+        }
+
+        return result;
+    }
+
+    protected <T> T ldValueNullCheck(T ldValue) throws AiConfigParseException {
+        if (ldValue == LDValue.ofNull()) {
+            throw new AiConfigParseException("Unexpected Null value for non-optional field");
+        }
+        return ldValue;
+    }
+
+    class AiConfigParseException extends Exception {
+        AiConfigParseException(String exceptionMessage) {
+            super(exceptionMessage);
         }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAiClient.java
@@ -75,15 +75,16 @@ public final class LDAiClient implements LDAiClientInterface {
         // expecting, which is good
         enabled = valueMeta.get("enabled").booleanValue();
 
-        String variationKey = null;
+        Meta meta = null;
+
         if (checkValueWithFailureLogging(valueMeta.get("variationKey"), LDValueType.STRING, logger,
                 "variationKey should be a string")) {
-            variationKey = valueMeta.get("variationKey").stringValue();
-        }
-        // Create Meta using constructor
-        Meta meta = new Meta(
+            String variationKey = valueMeta.get("variationKey").stringValue();
+
+            meta = new Meta(
                 variationKey,
                 Optional.of(valueMeta.get("version").intValue()));
+        }
 
         // Convert the optional model from an JSON object of with parameters and custom
         // into Model

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
@@ -6,9 +6,9 @@ public final class AiConfig {
     private final boolean enabled;
 
     private final Meta meta;
-    
+
     private final Model model;
-    
+
     private final List<Message> messages;
 
     private final Provider provider;

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
@@ -1,0 +1,45 @@
+package com.launchdarkly.sdk.server.ai.datamodel;
+
+import java.util.List;
+
+public class AiConfig {
+    private List<Message> messages;
+
+    private Meta meta;
+
+    private Model model;
+
+    private Provider provider;
+
+    public List<Message> getMessages() {
+        return messages;
+    }
+
+    public void setMessages(List<Message> messages) {
+        this.messages = messages;
+    }
+
+    public Meta getMeta() {
+        return meta;
+    }
+
+    public void setMeta(Meta meta) {
+        this.meta = meta;
+    }
+
+    public Model getModel() {
+        return model;
+    }
+
+    public void setModel(Model model) {
+        this.model = model;
+    }
+
+    public Provider getProvider() {
+        return provider;
+    }
+
+    public void setProvider(Provider provider) {
+        this.provider = provider;
+    }
+}

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
@@ -2,7 +2,7 @@ package com.launchdarkly.sdk.server.ai.datamodel;
 
 import java.util.List;
 
-public class AiConfig {
+public final class AiConfig {
     private List<Message> messages;
 
     private Meta meta;

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
@@ -13,7 +13,7 @@ public final class AiConfig {
 
     private final Provider provider;
 
-    public AiConfig(boolean enabled, Meta meta, Model model, List<Message> messages, Provider provider) {
+    AiConfig(boolean enabled, Meta meta, Model model, List<Message> messages, Provider provider) {
         this.enabled = enabled;
         this.meta = meta;
         this.model = model;
@@ -39,5 +39,48 @@ public final class AiConfig {
 
     public Provider getProvider() {
         return provider;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private boolean enabled;
+        private Meta meta;
+        private Model model;
+        private List<Message> messages;
+        private Provider provider;
+        
+        private Builder() {}
+        
+        public Builder enabled(boolean enabled) {
+            this.enabled = enabled;
+            return this;
+        }
+        
+        public Builder meta(Meta meta) {
+            this.meta = meta;
+            return this;
+        }
+        
+        public Builder model(Model model) {
+            this.model = model;
+            return this;
+        }
+        
+        public Builder messages(List<Message> messages) {
+            this.messages = messages;
+            return this;
+        }
+        
+        public Builder provider(Provider provider) {
+            this.provider = provider;
+            return this;
+        }
+        
+        public AiConfig build() {
+            return new AiConfig(enabled, meta, model, messages, provider);
+        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/AiConfig.java
@@ -3,43 +3,41 @@ package com.launchdarkly.sdk.server.ai.datamodel;
 import java.util.List;
 
 public final class AiConfig {
-    private List<Message> messages;
+    private final boolean enabled;
 
-    private Meta meta;
+    private final Meta meta;
+    
+    private final Model model;
+    
+    private final List<Message> messages;
 
-    private Model model;
+    private final Provider provider;
 
-    private Provider provider;
+    public AiConfig(boolean enabled, Meta meta, Model model, List<Message> messages, Provider provider) {
+        this.enabled = enabled;
+        this.meta = meta;
+        this.model = model;
+        this.messages = messages;
+        this.provider = provider;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
 
     public List<Message> getMessages() {
         return messages;
-    }
-
-    public void setMessages(List<Message> messages) {
-        this.messages = messages;
     }
 
     public Meta getMeta() {
         return meta;
     }
 
-    public void setMeta(Meta meta) {
-        this.meta = meta;
-    }
-
     public Model getModel() {
         return model;
     }
 
-    public void setModel(Model model) {
-        this.model = model;
-    }
-
     public Provider getProvider() {
         return provider;
-    }
-
-    public void setProvider(Provider provider) {
-        this.provider = provider;
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
@@ -1,0 +1,23 @@
+package com.launchdarkly.sdk.server.ai.datamodel;
+
+public class Message {
+    private String content;
+
+    private Role role;
+
+    public String getContent() {
+        return content;
+    }
+
+    public void setContent(String content) {
+        this.content = content;
+    }
+
+    public Role getRole() {
+        return role;
+    }
+
+    public void setRole(Role role) {
+        this.role = role;
+    }
+}

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
@@ -1,23 +1,20 @@
 package com.launchdarkly.sdk.server.ai.datamodel;
 
-public class Message {
+public final class Message {
     private String content;
 
     private Role role;
+
+    public Message(String content, Role role) {
+        this.content = content;
+        this.role = role;
+    }
 
     public String getContent() {
         return content;
     }
 
-    public void setContent(String content) {
-        this.content = content;
-    }
-
     public Role getRole() {
         return role;
-    }
-
-    public void setRole(Role role) {
-        this.role = role;
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
@@ -14,15 +14,18 @@ public final class Message {
 
         @Override
         public Message toType(LDValue ldValue) {
-            return new Message(ldValue.get("content").stringValue(), Role.getRole(ldValue.get("role").stringValue()));
+            return Message.builder()
+                .content(ldValue.get("content").stringValue())
+                .role(Role.getRole(ldValue.get("role").stringValue()))
+                .build();
         }
     }
 
-    private String content;
+    private final String content;
 
-    private Role role;
+    private final Role role;
 
-    public Message(String content, Role role) {
+    Message(String content, Role role) {
         this.content = content;
         this.role = role;
     }
@@ -33,5 +36,30 @@ public final class Message {
 
     public Role getRole() {
         return role;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private String content;
+        private Role role;
+        
+        private Builder() {}
+        
+        public Builder content(String content) {
+            this.content = content;
+            return this;
+        }
+        
+        public Builder role(Role role) {
+            this.role = role;
+            return this;
+        }
+        
+        public Message build() {
+            return new Message(content, role);
+        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Message.java
@@ -1,6 +1,23 @@
 package com.launchdarkly.sdk.server.ai.datamodel;
 
+import com.launchdarkly.sdk.LDValue;
+
 public final class Message {
+    public static class MessageConverter extends LDValue.Converter<Message> {
+        @Override
+        public LDValue fromType(Message message) {
+            return LDValue.buildObject()
+                    .put("content", message.getContent())
+                    .put("role", message.getRole().toString())
+                    .build();
+        }
+
+        @Override
+        public Message toType(LDValue ldValue) {
+            return new Message(ldValue.get("content").stringValue(), Role.getRole(ldValue.get("role").stringValue()));
+        }
+    }
+
     private String content;
 
     private Role role;

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -13,21 +13,18 @@ public final class Meta {
      */
     private final Optional<Integer> version;
 
-    /**
-     * If the config is enabled.
-     */
-    // private final boolean enabled;
+    // The enable paramter is taken outside of the Meta to be a top level value of
+    // AiConfig
 
     /**
      * Constructor for Meta with all required fields.
      * 
      * @param variationKey the variation key
-     * @param version the version
+     * @param version      the version
      */
     public Meta(String variationKey, Optional<Integer> version) {
         this.variationKey = variationKey;
         this.version = version != null ? version : Optional.empty();
-        // this.enabled = enabled;
     }
 
     public String getVariationKey() {
@@ -37,8 +34,4 @@ public final class Meta {
     public Optional<Integer> getVersion() {
         return version;
     }
-
-    // public boolean isEnabled() {
-    //     return enabled;
-    // }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -1,0 +1,46 @@
+package com.launchdarkly.sdk.server.ai.datamodel;
+
+import java.util.Optional;
+
+public class Meta {
+    /**
+     * The variation key.
+     */
+    private String variationKey;
+
+    /**
+     * The variation version.
+     */
+    private Optional<Integer> version;
+
+    /**
+     * If the config is enabled.
+     */
+    private boolean enabled;
+
+    // Getters and Setters
+
+    public String getVariationKey() {
+        return variationKey;
+    }
+
+    public void setVariationKey(String variationKey) {
+        this.variationKey = variationKey;
+    }
+
+    public Optional<Integer> getVersion() {
+        return version;
+    }
+
+    public void setVersion(Optional<Integer> version) {
+        this.version = version;
+    }
+
+    public boolean isEnabled() {
+        return enabled;
+    }
+
+    public void setEnabled(boolean enabled) {
+        this.enabled = enabled;
+    }
+}

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -22,7 +22,7 @@ public final class Meta {
      * @param variationKey the variation key
      * @param version      the version
      */
-    public Meta(String variationKey, Optional<Integer> version) {
+    Meta(String variationKey, Optional<Integer> version) {
         this.variationKey = variationKey;
         this.version = version != null ? version : Optional.empty();
     }
@@ -33,5 +33,35 @@ public final class Meta {
 
     public Optional<Integer> getVersion() {
         return version;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private String variationKey;
+        private Optional<Integer> version = Optional.empty();
+        
+        private Builder() {}
+        
+        public Builder variationKey(String variationKey) {
+            this.variationKey = variationKey;
+            return this;
+        }
+        
+        public Builder version(Optional<Integer> version) {
+            this.version = version;
+            return this;
+        }
+        
+        public Builder version(int version) {
+            this.version = Optional.of(version);
+            return this;
+        }
+        
+        public Meta build() {
+            return new Meta(variationKey, version);
+        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -16,19 +16,18 @@ public final class Meta {
     /**
      * If the config is enabled.
      */
-    private final boolean enabled;
+    // private final boolean enabled;
 
     /**
      * Constructor for Meta with all required fields.
      * 
      * @param variationKey the variation key
      * @param version the version
-     * @param enabled if the config is enabled
      */
-    public Meta(String variationKey, Optional<Integer> version, boolean enabled) {
+    public Meta(String variationKey, Optional<Integer> version) {
         this.variationKey = variationKey;
         this.version = version != null ? version : Optional.empty();
-        this.enabled = enabled;
+        // this.enabled = enabled;
     }
 
     public String getVariationKey() {
@@ -39,7 +38,7 @@ public final class Meta {
         return version;
     }
 
-    public boolean isEnabled() {
-        return enabled;
-    }
+    // public boolean isEnabled() {
+    //     return enabled;
+    // }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -6,41 +6,40 @@ public final class Meta {
     /**
      * The variation key.
      */
-    private String variationKey;
+    private final String variationKey;
 
     /**
      * The variation version.
      */
-    private Optional<Integer> version;
+    private final Optional<Integer> version;
 
     /**
      * If the config is enabled.
      */
-    private boolean enabled;
+    private final boolean enabled;
 
-    // Getters and Setters
+    /**
+     * Constructor for Meta with all required fields.
+     * 
+     * @param variationKey the variation key
+     * @param version the version
+     * @param enabled if the config is enabled
+     */
+    public Meta(String variationKey, Optional<Integer> version, boolean enabled) {
+        this.variationKey = variationKey;
+        this.version = version != null ? version : Optional.empty();
+        this.enabled = enabled;
+    }
 
     public String getVariationKey() {
         return variationKey;
-    }
-
-    public void setVariationKey(String variationKey) {
-        this.variationKey = variationKey;
     }
 
     public Optional<Integer> getVersion() {
         return version;
     }
 
-    public void setVersion(Optional<Integer> version) {
-        this.version = version;
-    }
-
     public boolean isEnabled() {
         return enabled;
-    }
-
-    public void setEnabled(boolean enabled) {
-        this.enabled = enabled;
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Meta.java
@@ -2,7 +2,7 @@ package com.launchdarkly.sdk.server.ai.datamodel;
 
 import java.util.Optional;
 
-public class Meta {
+public final class Meta {
     /**
      * The variation key.
      */

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
@@ -16,13 +16,14 @@ public final class Model {
     /**
      * Constructor for Model with all required fields.
      * 
-     * @param name the model name
+     * @param name       the model name
      * @param parameters the parameters map
-     * @param custom the custom map
+     * @param custom     the custom map
      */
     public Model(String name, Map<String, LDValue> parameters, Map<String, LDValue> custom) {
         this.name = name;
-        this.parameters = parameters != null ? Collections.unmodifiableMap(new HashMap<>(parameters)) : Collections.emptyMap();
+        this.parameters = parameters != null ? Collections.unmodifiableMap(new HashMap<>(parameters))
+                : Collections.emptyMap();
         this.custom = custom != null ? Collections.unmodifiableMap(new HashMap<>(custom)) : Collections.emptyMap();
     }
 

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
@@ -20,7 +20,7 @@ public final class Model {
      * @param parameters the parameters map
      * @param custom     the custom map
      */
-    public Model(String name, Map<String, LDValue> parameters, Map<String, LDValue> custom) {
+    Model(String name, Map<String, LDValue> parameters, Map<String, LDValue> custom) {
         this.name = name;
         this.parameters = parameters != null ? Collections.unmodifiableMap(new HashMap<>(parameters))
                 : Collections.emptyMap();
@@ -37,5 +37,36 @@ public final class Model {
 
     public Map<String, LDValue> getCustom() {
         return custom;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private String name;
+        private Map<String, LDValue> parameters;
+        private Map<String, LDValue> custom;
+        
+        private Builder() {}
+        
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+        
+        public Builder parameters(Map<String, LDValue> parameters) {
+            this.parameters = parameters;
+            return this;
+        }
+        
+        public Builder custom(Map<String, LDValue> custom) {
+            this.custom = custom;
+            return this;
+        }
+        
+        public Model build() {
+            return new Model(name, parameters, custom);
+        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
@@ -4,7 +4,7 @@ import java.util.HashMap;
 
 import com.launchdarkly.sdk.LDValue;
 
-public class Model {
+public final class Model {
     private String name;
 
     private HashMap<String, LDValue> parameters;

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
@@ -1,39 +1,40 @@
 package com.launchdarkly.sdk.server.ai.datamodel;
 
+import java.util.Collections;
 import java.util.HashMap;
+import java.util.Map;
 
 import com.launchdarkly.sdk.LDValue;
 
 public final class Model {
-    private String name;
+    private final String name;
 
-    private HashMap<String, LDValue> parameters;
+    private final Map<String, LDValue> parameters;
 
-    private HashMap<String, LDValue> custom;
+    private final Map<String, LDValue> custom;
 
-    // Getters and Setters
+    /**
+     * Constructor for Model with all required fields.
+     * 
+     * @param name the model name
+     * @param parameters the parameters map
+     * @param custom the custom map
+     */
+    public Model(String name, Map<String, LDValue> parameters, Map<String, LDValue> custom) {
+        this.name = name;
+        this.parameters = parameters != null ? Collections.unmodifiableMap(new HashMap<>(parameters)) : Collections.emptyMap();
+        this.custom = custom != null ? Collections.unmodifiableMap(new HashMap<>(custom)) : Collections.emptyMap();
+    }
 
     public String getName() {
         return name;
     }
 
-    public void setName(String name) {
-        this.name = name;
-    }
-
-    public HashMap<String, LDValue> getParameters() {
+    public Map<String, LDValue> getParameters() {
         return parameters;
     }
 
-    public void setParameters(HashMap<String, LDValue> parameters) {
-        this.parameters = parameters;
-    }
-
-    public HashMap<String, LDValue> getCustom() {
+    public Map<String, LDValue> getCustom() {
         return custom;
-    }
-
-    public void setCustom(HashMap<String, LDValue> custom) {
-        this.custom = custom;
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Model.java
@@ -1,0 +1,39 @@
+package com.launchdarkly.sdk.server.ai.datamodel;
+
+import java.util.HashMap;
+
+import com.launchdarkly.sdk.LDValue;
+
+public class Model {
+    private String name;
+
+    private HashMap<String, LDValue> parameters;
+
+    private HashMap<String, LDValue> custom;
+
+    // Getters and Setters
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+
+    public HashMap<String, LDValue> getParameters() {
+        return parameters;
+    }
+
+    public void setParameters(HashMap<String, LDValue> parameters) {
+        this.parameters = parameters;
+    }
+
+    public HashMap<String, LDValue> getCustom() {
+        return custom;
+    }
+
+    public void setCustom(HashMap<String, LDValue> custom) {
+        this.custom = custom;
+    }
+}

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
@@ -1,13 +1,13 @@
 package com.launchdarkly.sdk.server.ai.datamodel;
 
-public class Provider {
+public final class Provider {
     private String name;
+
+    public Provider(String name) {
+        this.name = name;
+    }
 
     public String getName() {
         return name;
-    }
-
-    public void setName(String name) {
-        this.name = name;
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
@@ -1,13 +1,32 @@
 package com.launchdarkly.sdk.server.ai.datamodel;
 
 public final class Provider {
-    private String name;
+    private final String name;
 
-    public Provider(String name) {
+    Provider(String name) {
         this.name = name;
     }
 
     public String getName() {
         return name;
+    }
+    
+    public static Builder builder() {
+        return new Builder();
+    }
+    
+    public static final class Builder {
+        private String name;
+        
+        private Builder() {}
+        
+        public Builder name(String name) {
+            this.name = name;
+            return this;
+        }
+        
+        public Provider build() {
+            return new Provider(name);
+        }
     }
 }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Provider.java
@@ -1,0 +1,13 @@
+package com.launchdarkly.sdk.server.ai.datamodel;
+
+public class Provider {
+    private String name;
+
+    public String getName() {
+        return name;
+    }
+
+    public void setName(String name) {
+        this.name = name;
+    }
+}

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Role.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/Role.java
@@ -7,13 +7,37 @@ public enum Role {
     /**
      * User Role
      */
-    USER,
+    USER("user"),
     /**
      * System Role
      */
-    SYSTEM,
+    SYSTEM("system"),
     /**
      * Assistant Role
      */
-    ASSISTANT
+    ASSISTANT("assistant");
+
+    private final String role;
+
+    private Role(String role) {
+        this.role = role;
+    }
+
+    public static Role getRole(String role) {
+        switch (role) {
+            case "user":
+                return USER;
+            case "system":
+                return SYSTEM;
+            case "assistant":
+                return ASSISTANT;
+            default:
+                return null;
+        }
+    }
+
+    @Override
+    public String toString() {
+        return role;
+    }
 }

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
@@ -4,7 +4,6 @@ import org.junit.Test;
 
 import com.launchdarkly.sdk.LDValue;
 import com.launchdarkly.sdk.server.ai.datamodel.AiConfig;
-import com.launchdarkly.sdk.server.ai.datamodel.Message;
 import com.launchdarkly.sdk.server.ai.datamodel.Role;
 
 import static org.junit.Assert.assertEquals;
@@ -13,36 +12,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.assertFalse;
 
-import java.util.List;
-import java.util.Map;
-
 public class LDAiClientTest {
-    /**
-     * Helper method to generate valid JSON with all required fields
-     * This can be modified for specific test cases
-     */
-    private String getValidBaseJson() {
-        return "{\n" + //
-                "  \"_ldMeta\": {\n" + //
-                "    \"variationKey\" : \"1234\",\n" + //
-                "    \"enabled\": true,\n" + //
-                "    \"version\": 1\n" + //
-                "  },\n" + //
-                "  \"messages\": [\n" + //
-                "    {\n" + //
-                "      \"content\": \"This is an {{ adjective }} message.\",\n" + //
-                "      \"role\": \"user\"\n" + //
-                "    }\n" + //
-                "  ],\n" + //
-                "  \"model\": {\n" + //
-                "    \"name\": \"my-cool-custom-model\"\n" + //
-                "  },\n" + //
-                "  \"provider\": {\n" + //
-                "    \"name\" : \"provider-name\"\n" + //
-                "  }\n" + //
-                "}";
-    }
-
     /**
      * Tests that a complete valid JSON is properly converted to an AiConfig object
      */
@@ -382,8 +352,7 @@ public class LDAiClientTest {
         LDAiClient client = new LDAiClient(null);
         AiConfig result = client.parseAiConfig(input, "Whatever");
 
-        assertNotNull(result.getProvider());
-        assertNull(result.getProvider().getName());
+        assertNull(result.getProvider());
     }
 
     /**
@@ -401,6 +370,7 @@ public class LDAiClientTest {
         assertNull(result.getMeta());
         assertNull(result.getModel());
         assertNull(result.getMessages());
+        assertNull(result.getProvider());
     }
 
     /**
@@ -422,5 +392,6 @@ public class LDAiClientTest {
         assertNull(result.getMeta()); // Meta should be null due to missing variationKey
         assertNull(result.getModel());
         assertNull(result.getMessages());
+        assertNull(result.getProvider());
     }
 }

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
@@ -1,0 +1,60 @@
+package com.launchdarkly.sdk.server.ai;
+
+import org.junit.Test;
+
+import com.launchdarkly.sdk.LDValue;
+import com.launchdarkly.sdk.server.ai.datamodel.AiConfig;
+import com.launchdarkly.sdk.server.ai.datamodel.Role;
+
+import static org.junit.Assert.assertEquals;
+
+public class LDAiClientTest {
+    @Test 
+    public void testParseAiConfig() {
+        String rawJson = "{\n" + //
+                        "  \"_ldMeta\": {\n" + //
+                        "    \"variationKey\" : 1234,\n" + //
+                        "    \"enabled\": true,\n" + //
+                        "    \"version\": 1\n" + //
+                        "  },\n" + //
+                        "  \"messages\": [\n" + //
+                        "    {\n" + //
+                        "      \"content\": \"This is an {{ adjective }} message.\",\n" + //
+                        "      \"role\": \"user\"\n" + //
+                        "    },\n" + //
+                        "    {\n" + //
+                        "      \"content\": \"{{ greeting}}, this is another message!\",\n" + //
+                        "      \"role\": \"system\"\n" + //
+                        "    },\n" + //
+                        "    {\n" + //
+                        "      \"content\": \"This is the final {{ noun }}.\",\n" + //
+                        "      \"role\": \"assistant\"\n" + //
+                        "    }\n" + //
+                        "  ],\n" + //
+                        "  \"model\": {\n" + //
+                        "    \"name\": \"my-cool-custom-model\",\n" + //
+                        "    \"parameters\": {\n" + //
+                        "      \"foo\" : \"bar\",\n" + //
+                        "      \"baz\" : 23,\n" + //
+                        "      \"qux\" : true,\n" + //
+                        "      \"whatever\" : [],\n" + //
+                        "      \"another\" : {}\n" + //
+                        "    }\n" + //
+                        "  },\n" + //
+                        "  \"provider\": {\n" + //
+                        "    \"name\" : \"provider-name\"\n" + //
+                        "  }\n" + //
+                        "}";
+
+        LDValue input = LDValue.parse(rawJson);
+            
+        LDAiClient client = new LDAiClient(null);
+
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertEquals(Role.USER, result.getMessages().get(0).getRole());
+        assertEquals(Integer.valueOf(1), result.getMeta().getVersion().orElse(0));
+        assertEquals(LDValue.of(true), result.getModel().getParameters().get("qux"));
+        assertEquals("provider-name", result.getProvider().getName());
+    };
+}

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
@@ -13,7 +13,7 @@ public class LDAiClientTest {
     public void testParseAiConfig() {
         String rawJson = "{\n" + //
                 "  \"_ldMeta\": {\n" + //
-                "    \"variationKey\" : 1234,\n" + //
+                "    \"variationKey\" : \"1234\",\n" + //
                 "    \"enabled\": true,\n" + //
                 "    \"version\": 1\n" + //
                 "  },\n" + //

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
@@ -4,13 +4,50 @@ import org.junit.Test;
 
 import com.launchdarkly.sdk.LDValue;
 import com.launchdarkly.sdk.server.ai.datamodel.AiConfig;
+import com.launchdarkly.sdk.server.ai.datamodel.Message;
 import com.launchdarkly.sdk.server.ai.datamodel.Role;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertTrue;
+import static org.junit.Assert.assertFalse;
+
+import java.util.List;
+import java.util.Map;
 
 public class LDAiClientTest {
+    /**
+     * Helper method to generate valid JSON with all required fields
+     * This can be modified for specific test cases
+     */
+    private String getValidBaseJson() {
+        return "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"1234\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [\n" + //
+                "    {\n" + //
+                "      \"content\": \"This is an {{ adjective }} message.\",\n" + //
+                "      \"role\": \"user\"\n" + //
+                "    }\n" + //
+                "  ],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"my-cool-custom-model\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+    }
+
+    /**
+     * Tests that a complete valid JSON is properly converted to an AiConfig object
+     */
     @Test
-    public void testParseAiConfig() {
+    public void testCompleteAiConfig() {
         String rawJson = "{\n" + //
                 "  \"_ldMeta\": {\n" + //
                 "    \"variationKey\" : \"1234\",\n" + //
@@ -47,9 +84,7 @@ public class LDAiClientTest {
                 "}";
 
         LDValue input = LDValue.parse(rawJson);
-
         LDAiClient client = new LDAiClient(null);
-
         AiConfig result = client.parseAiConfig(input, "Whatever");
 
         assertEquals(Role.USER, result.getMessages().get(0).getRole());
@@ -57,5 +92,335 @@ public class LDAiClientTest {
         assertEquals(Integer.valueOf(1), result.getMeta().getVersion().orElse(0));
         assertEquals(LDValue.of(true), result.getModel().getParameters().get("qux"));
         assertEquals("provider-name", result.getProvider().getName());
-    };
+        assertTrue(result.isEnabled());
+    }
+
+    /**
+     * Tests that a valid Meta object is correctly parsed
+     */
+    @Test
+    public void testValidMeta() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key-123\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 42\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getMeta());
+        assertEquals("key-123", result.getMeta().getVariationKey());
+        assertEquals(Integer.valueOf(42), result.getMeta().getVersion().orElse(0));
+        assertTrue(result.isEnabled());
+    }
+
+    /**
+     * Tests that invalid Meta with number as variationKey is handled properly
+     */
+    @Test
+    public void testInvalidMetaNumberAsVariationKey() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : 123,\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNull(result.getMeta());
+    }
+
+    /**
+     * Tests that valid Messages are correctly parsed
+     */
+    @Test
+    public void testValidMessages() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key-123\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [\n" + //
+                "    {\n" + //
+                "      \"content\": \"User message\",\n" + //
+                "      \"role\": \"user\"\n" + //
+                "    },\n" + //
+                "    {\n" + //
+                "      \"content\": \"System message\",\n" + //
+                "      \"role\": \"system\"\n" + //
+                "    },\n" + //
+                "    {\n" + //
+                "      \"content\": \"Assistant message\",\n" + //
+                "      \"role\": \"assistant\"\n" + //
+                "    }\n" + //
+                "  ],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getMessages());
+        assertEquals(3, result.getMessages().size());
+        
+        assertEquals(Role.USER, result.getMessages().get(0).getRole());
+        assertEquals("User message", result.getMessages().get(0).getContent());
+        
+        assertEquals(Role.SYSTEM, result.getMessages().get(1).getRole());
+        assertEquals("System message", result.getMessages().get(1).getContent());
+        
+        assertEquals(Role.ASSISTANT, result.getMessages().get(2).getRole());
+        assertEquals("Assistant message", result.getMessages().get(2).getContent());
+    }
+
+    /**
+     * Tests that invalid Messages with wrong role type are handled properly
+     */
+    @Test
+    public void testInvalidMessagesInvalidRole() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [\n" + //
+                "    {\n" + //
+                "      \"content\": \"Invalid role\",\n" + //
+                "      \"role\": \"invalid_role_value\"\n" + //
+                "    }\n" + //
+                "  ],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getMessages());
+        assertEquals(1, result.getMessages().size());
+        assertNull(result.getMessages().get(0).getRole());
+    }
+
+    /**
+     * Tests that a valid Model object is correctly parsed
+     */
+    @Test
+    public void testValidModel() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"test-model\",\n" + //
+                "    \"parameters\": {\n" + //
+                "      \"string_param\" : \"value\",\n" + //
+                "      \"number_param\" : 42,\n" + //
+                "      \"bool_param\" : true,\n" + //
+                "      \"array_param\" : [1, 2, 3],\n" + //
+                "      \"object_param\" : {\"key\": \"value\"}\n" + //
+                "    },\n" + //
+                "    \"custom\": {\n" + //
+                "      \"custom_key\": \"custom_value\"\n" + //
+                "    }\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getModel());
+        assertEquals("test-model", result.getModel().getName());
+        
+        assertNotNull(result.getModel().getParameters());
+        assertEquals(5, result.getModel().getParameters().size());
+        assertEquals(LDValue.of("value"), result.getModel().getParameters().get("string_param"));
+        assertEquals(LDValue.of(42), result.getModel().getParameters().get("number_param"));
+        assertEquals(LDValue.of(true), result.getModel().getParameters().get("bool_param"));
+        
+        assertNotNull(result.getModel().getCustom());
+        assertEquals(1, result.getModel().getCustom().size());
+        assertEquals(LDValue.of("custom_value"), result.getModel().getCustom().get("custom_key"));
+    }
+
+    /**
+     * Tests that invalid Model with name as non-string is handled properly
+     */
+    @Test
+    public void testInvalidModelNameType() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": 123,\n" + //
+                "    \"parameters\": {}\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNull(result.getModel());
+    }
+
+    /**
+     * Tests that a valid Provider object is correctly parsed
+     */
+    @Test
+    public void testValidProvider() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"test-provider\"\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getProvider());
+        assertEquals("test-provider", result.getProvider().getName());
+    }
+
+    /**
+     * Tests that invalid Provider with name as non-string is handled properly
+     */
+    @Test
+    public void testInvalidProviderNameType() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : \"key\",\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [{\n" + //
+                "    \"content\": \"content\",\n" + //
+                "    \"role\": \"user\"\n" + //
+                "  }],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"model-name\"\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : 123\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertNotNull(result.getProvider());
+        assertNull(result.getProvider().getName());
+    }
+
+    /**
+     * Tests that a completely invalid JSON input (not an object) is handled properly
+     */
+    @Test
+    public void testInvalidJsonNotObject() {
+        String json = "[]"; // Array instead of object
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertFalse(result.isEnabled());
+        assertNull(result.getMeta());
+        assertNull(result.getModel());
+        assertNull(result.getMessages());
+    }
+
+    /**
+     * Tests that a JSON with missing required properties is handled properly
+     */
+    @Test
+    public void testMissingRequiredProperties() {
+        String json = "{\n" + //
+                "  \"_ldMeta\": {\n" + //
+                "    \"enabled\": true\n" + //
+                "  }\n" + //
+                "}";
+
+        LDValue input = LDValue.parse(json);
+        LDAiClient client = new LDAiClient(null);
+        AiConfig result = client.parseAiConfig(input, "Whatever");
+
+        assertTrue(result.isEnabled()); // enabled is present and true
+        assertNull(result.getMeta()); // Meta should be null due to missing variationKey
+        assertNull(result.getModel());
+        assertNull(result.getMessages());
+    }
 }

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAiClientTest.java
@@ -9,50 +9,51 @@ import com.launchdarkly.sdk.server.ai.datamodel.Role;
 import static org.junit.Assert.assertEquals;
 
 public class LDAiClientTest {
-    @Test 
+    @Test
     public void testParseAiConfig() {
         String rawJson = "{\n" + //
-                        "  \"_ldMeta\": {\n" + //
-                        "    \"variationKey\" : 1234,\n" + //
-                        "    \"enabled\": true,\n" + //
-                        "    \"version\": 1\n" + //
-                        "  },\n" + //
-                        "  \"messages\": [\n" + //
-                        "    {\n" + //
-                        "      \"content\": \"This is an {{ adjective }} message.\",\n" + //
-                        "      \"role\": \"user\"\n" + //
-                        "    },\n" + //
-                        "    {\n" + //
-                        "      \"content\": \"{{ greeting}}, this is another message!\",\n" + //
-                        "      \"role\": \"system\"\n" + //
-                        "    },\n" + //
-                        "    {\n" + //
-                        "      \"content\": \"This is the final {{ noun }}.\",\n" + //
-                        "      \"role\": \"assistant\"\n" + //
-                        "    }\n" + //
-                        "  ],\n" + //
-                        "  \"model\": {\n" + //
-                        "    \"name\": \"my-cool-custom-model\",\n" + //
-                        "    \"parameters\": {\n" + //
-                        "      \"foo\" : \"bar\",\n" + //
-                        "      \"baz\" : 23,\n" + //
-                        "      \"qux\" : true,\n" + //
-                        "      \"whatever\" : [],\n" + //
-                        "      \"another\" : {}\n" + //
-                        "    }\n" + //
-                        "  },\n" + //
-                        "  \"provider\": {\n" + //
-                        "    \"name\" : \"provider-name\"\n" + //
-                        "  }\n" + //
-                        "}";
+                "  \"_ldMeta\": {\n" + //
+                "    \"variationKey\" : 1234,\n" + //
+                "    \"enabled\": true,\n" + //
+                "    \"version\": 1\n" + //
+                "  },\n" + //
+                "  \"messages\": [\n" + //
+                "    {\n" + //
+                "      \"content\": \"This is an {{ adjective }} message.\",\n" + //
+                "      \"role\": \"user\"\n" + //
+                "    },\n" + //
+                "    {\n" + //
+                "      \"content\": \"{{ greeting}}, this is another message!\",\n" + //
+                "      \"role\": \"system\"\n" + //
+                "    },\n" + //
+                "    {\n" + //
+                "      \"content\": \"This is the final {{ noun }}.\",\n" + //
+                "      \"role\": \"assistant\"\n" + //
+                "    }\n" + //
+                "  ],\n" + //
+                "  \"model\": {\n" + //
+                "    \"name\": \"my-cool-custom-model\",\n" + //
+                "    \"parameters\": {\n" + //
+                "      \"foo\" : \"bar\",\n" + //
+                "      \"baz\" : 23,\n" + //
+                "      \"qux\" : true,\n" + //
+                "      \"whatever\" : [],\n" + //
+                "      \"another\" : {}\n" + //
+                "    }\n" + //
+                "  },\n" + //
+                "  \"provider\": {\n" + //
+                "    \"name\" : \"provider-name\"\n" + //
+                "  }\n" + //
+                "}";
 
         LDValue input = LDValue.parse(rawJson);
-            
+
         LDAiClient client = new LDAiClient(null);
 
         AiConfig result = client.parseAiConfig(input, "Whatever");
 
         assertEquals(Role.USER, result.getMessages().get(0).getRole());
+        assertEquals("This is the final {{ noun }}.", result.getMessages().get(2).getContent());
         assertEquals(Integer.valueOf(1), result.getMeta().getVersion().orElse(0));
         assertEquals(LDValue.of(true), result.getModel().getParameters().get("qux"));
         assertEquals("provider-name", result.getProvider().getName());


### PR DESCRIPTION
# Convert JSON LDValue into the AiConfig Object

For ease of discussion, implement only the conversion logic from LDValue (that we will get back from the Feature Flag SDK) to the AiConfig DataModel. 

This uses the exception-based short circuiting (similar to https://github.com/launchdarkly/dotnet-core/blob/6774539af1a2f87b96ae3e647fdcdc5663c791ab/pkgs/sdk/server-ai/src/LdAiClient.cs#L180) and LDValue reading logic similar to https://github.com/launchdarkly/python-server-sdk-ai/blob/main/ldai/client.py#L134

## Updates
- Implemented builder pattern for all classes in the datamodel directory
- Made all constructors package-private
- Updated LDAiClient to use the builder pattern
- Made fields final for immutability
- All tests are passing

## Link to Devin run
https://app.devin.ai/sessions/f1057ea9206643789c93d45aa8c5c500

Requested by: lchan@launchdarkly.com

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Introduces new JSON parsing and null-handling behavior that will affect how AI configs are interpreted at runtime; errors could lead to silently missing fields or disabled configs. CI workflow addition is low risk.
> 
> **Overview**
> Adds a dedicated GitHub Actions workflow to build/test the `lib/sdk/server-ai` workspace on pushes/PRs.
> 
> Implements `LDAiClient.parseAiConfig` to parse an `LDValue` JSON object into a new immutable `AiConfig` datamodel (`Meta`, `Model`, `Message`, `Provider`), including type-checking with error logging and null/disabled fallbacks for malformed inputs. Updates `Role` string serialization/parsing and adds comprehensive JUnit coverage for valid/invalid JSON cases.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 5244939b8ab26f4ec7e20e0e3c349ad3ac939e59. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->