### PR TITLE
chore: Fix next release notes for Server SDK

### DIFF
--- a/release-please-config.json
+++ b/release-please-config.json
@@ -1,5 +1,5 @@
 {
-  "bootstrap-sha": "4b8717e9622cd7789ded706470b7109e04ce6825",
+  "bootstrap-sha": "9e3f458fd0b2dff7acd8ba73d605061ac91eec28",
   "separate-pull-requests": true,
   "include-component-in-tag": true,
   "packages": {


### PR DESCRIPTION
Between Server 7.7.0 and 7.8.0 we added the package-name property to `release-please-config.json`. Because of this, release please no longer recognizes the prior version and is pulling already release features into the next one. 