### PR TITLE
fix: migrating publishing to use central portal

### DIFF
--- a/.github/workflows/manual-publish.yml
+++ b/.github/workflows/manual-publish.yml
@@ -38,8 +38,8 @@ jobs:
         name: Get secrets
         with:
           aws_assume_role: ${{ vars.AWS_ROLE_ARN }}
-          ssm_parameter_pairs: '/production/common/releasing/sonatype/username = SONATYPE_USER_NAME,
-          /production/common/releasing/sonatype/password = SONATYPE_PASSWORD,
+          ssm_parameter_pairs: '/production/common/releasing/sonatype/central/username = SONATYPE_USER_NAME,
+          /production/common/releasing/sonatype/central/password = SONATYPE_PASSWORD,
           /production/common/releasing/java/keyId = SIGNING_KEY_ID'
           s3_path_pairs: 'launchdarkly-releaser/java/code-signing-keyring.gpg = code-signing-keyring.gpg'
 

--- a/lib/sdk/server/build.gradle
+++ b/lib/sdk/server/build.gradle
@@ -600,7 +600,10 @@ if (project == rootProject) {
     nexusPublishing {
         clientTimeout = java.time.Duration.ofMinutes(2) // we've seen extremely long delays in creating repositories
         repositories {
-            sonatype()
+            sonatype{
+                nexusUrl.set(uri("https://ossrh-staging-api.central.sonatype.com/service/local/"))
+                snapshotRepositoryUrl.set(uri("https://central.sonatype.com/repository/maven-snapshots/"))
+            }
         }
     }
 }


### PR DESCRIPTION
Following https://central.sonatype.org/publish/publish-portal-ossrh-staging-api/ as OSSRH is now deprecated.