### PR TITLE
feat: LDContext is java.io.Serializable

### DIFF
--- a/lib/shared/common/src/main/java/com/launchdarkly/sdk/AttributeMap.java
+++ b/lib/shared/common/src/main/java/com/launchdarkly/sdk/AttributeMap.java
@@ -1,9 +1,10 @@
 package com.launchdarkly.sdk;
 
+import java.io.Serializable;
 import java.util.HashMap;
 import java.util.Map;
 
-final class AttributeMap {
+final class AttributeMap implements Serializable {
   private final AttributeMap parent;
   private final Map<String, LDValue> map;
 

--- a/lib/shared/common/src/main/java/com/launchdarkly/sdk/LDValueBool.java
+++ b/lib/shared/common/src/main/java/com/launchdarkly/sdk/LDValueBool.java
@@ -38,4 +38,10 @@ final class LDValueBool extends LDValue {
   void write(JsonWriter writer) throws IOException {
     writer.value(value);
   }
+
+  // Preserve singleton identity after Java deserialization, since equals() for booleans
+  // relies on TRUE and FALSE being singletons.
+  private Object readResolve() {
+    return fromBoolean(value);
+  }
 }

--- a/lib/shared/common/src/main/java/com/launchdarkly/sdk/LDValueNull.java
+++ b/lib/shared/common/src/main/java/com/launchdarkly/sdk/LDValueNull.java
@@ -26,4 +26,9 @@ final class LDValueNull extends LDValue {
   void write(JsonWriter writer) throws IOException {
     writer.nullValue();
   }
+
+  // Preserve singleton identity after Java deserialization.
+  private Object readResolve() {
+    return INSTANCE;
+  }
 }

--- a/lib/shared/common/src/main/java/com/launchdarkly/sdk/json/JsonSerializable.java
+++ b/lib/shared/common/src/main/java/com/launchdarkly/sdk/json/JsonSerializable.java
@@ -1,10 +1,12 @@
 package com.launchdarkly.sdk.json;
 
+import java.io.Serializable;
+
 /**
  * Marker interface for SDK classes that have a custom JSON serialization.
  * 
  * @see JsonSerialization
  * @see LDGson
  */
-public interface JsonSerializable { 
+public interface JsonSerializable extends Serializable {
 }

--- a/lib/shared/common/src/test/java/com/launchdarkly/sdk/LDContextTest.java
+++ b/lib/shared/common/src/test/java/com/launchdarkly/sdk/LDContextTest.java
@@ -4,6 +4,10 @@ import com.launchdarkly.sdk.json.JsonSerialization;
 
 import org.junit.Test;
 
+import java.io.ByteArrayInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.ObjectInputStream;
+import java.io.ObjectOutputStream;
 import java.util.ArrayList;
 import java.util.List;
 
@@ -437,4 +441,40 @@ public class LDContextTest {
     assertThat(c2.isValid(), is(false));
     assertThat(c2.getError(), equalTo(Errors.CONTEXT_NO_KEY));
 }
+
+  @Test
+  public void javaSerializationRoundTripSingleKind() throws Exception {
+    LDContext c = LDContext.builder(kind1, "my-key")
+        .name("my-name")
+        .anonymous(true)
+        .set("email", "x@example.com")
+        .set("happy", true)
+        .set("count", 3)
+        .set("tags", LDValue.buildArray().add("a").add("b").build())
+        .set("nested", LDValue.buildObject().put("inner", "v").build())
+        .privateAttributes("email")
+        .build();
+
+    assertThat(javaSerializeAndDeserialize(c), equalTo(c));
+  }
+
+  @Test
+  public void javaSerializationRoundTripMultiKind() throws Exception {
+    LDContext c = LDContext.createMulti(
+        LDContext.builder(kind1, "key1").set("a", "b").build(),
+        LDContext.builder(kind2, "key2").set("c", LDValue.buildArray().add(1).add(2).build()).build()
+    );
+
+    assertThat(javaSerializeAndDeserialize(c), equalTo(c));
+  }
+
+  private static LDContext javaSerializeAndDeserialize(LDContext c) throws Exception {
+    ByteArrayOutputStream bytes = new ByteArrayOutputStream();
+    try (ObjectOutputStream out = new ObjectOutputStream(bytes)) {
+      out.writeObject(c);
+    }
+    try (ObjectInputStream in = new ObjectInputStream(new ByteArrayInputStream(bytes.toByteArray()))) {
+      return (LDContext) in.readObject();
+    }
+  }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Describe the solution you've provided**

I Added `Serializable` to any base classes and interfaces needed to make `LDContext` itself serializable

**Describe alternatives you've considered**

My workaround for this was to manually serialize the LDContext to json because `string` is serializable and deserialize it again

**Additional context**

I was trying to use launchdarkly sdks inside of some gradle tooling that configures build features based on feature flags. To do this I wrote a `ValueSource` which took the following parameters:

* Feature flag key
* SDK key
* LDContext

And gradle threw an error because LDContext is not serializable, and therefore not allowed as a ValueSourceParameters property.

I'm hoping that code will be open source soon, but for now here's a snippet:

```kotlin
abstract class LDBooleanValueSource: ValueSource<Boolean, LDBooleanValueSource.Params> {
  interface Params : ValueSourceParameters {
    val flagName: Property<String>
    val sdkKey: Property<String>
    val context: Property<LDContext> // Not serializable!
  }

  companion object {
    private val config: LDConfig = LDConfig.Builder().build()

    @JvmStatic
    fun ProviderFactory.launchDarklyBoolean(flagName: String, context: LDContext): Provider<Boolean> {
      return of(LDBooleanValueSource::class.java) {
        it.parameters.flagName.set(flagName)
        it.parameters.sdkKey.set(gradleProperty("launchdarkly.sdkKey"))
        it.parameters.context.set(context)
      }
    }
  }

  private val client by lazy { LDClient(parameters.sdkKey.get(), config) }

  override fun obtain(): Boolean =
    client.allFlagsState(parameters.context.get())
      .getFlagValue(parameters.flagName.get())
      .booleanValue()
}
```

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API change on marker interfaces and internal types; behavior is covered by new serialization round-trip tests with no runtime path changes for normal SDK usage.
> 
> **Overview**
> Enables **Java native serialization** (`ObjectOutputStream` / `ObjectInputStream`) for `LDContext`, so it can be used in frameworks that require `Serializable` parameters (e.g. Gradle `ValueSource` configuration) without JSON workarounds.
> 
> `JsonSerializable` now extends `java.io.Serializable`, which propagates serializability to `LDContext` and related JSON-modeled SDK types. **`AttributeMap`** is also marked `Serializable` directly. **`LDValueBool`** and **`LDValueNull`** add `readResolve()` so deserialized values restore the canonical singleton instances—required for `equals()` to behave correctly after a round trip.
> 
> New tests in `LDContextTest` assert single- and multi-kind contexts survive a Java serialize/deserialize cycle and remain `equalTo` the original.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f1ed0c7cdb86f3f4f629e1f0a73ad3131f422887. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->