### PR TITLE
fix: honor FDv1 fallback directive during initializer phase

### DIFF
--- a/lib/sdk/server/Makefile
+++ b/lib/sdk/server/Makefile
@@ -33,8 +33,8 @@ run-contract-tests:
 	@curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v2/downloader/run.sh \
       | VERSION=v2 PARAMS="-url http://localhost:$(TEST_SERVICE_PORT) -debug -skip-from=$(SUPPRESSION_FILE) $(TEST_HARNESS_PARAMS_V2)" sh
 	@echo "Running SDK contract test v3..."
-	@curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3.0.0-alpha.3/downloader/run.sh \
-      | VERSION=v3.0.0-alpha.3 PARAMS="-url http://localhost:$(TEST_SERVICE_PORT) -debug -stop-service-at-end -skip-from=$(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh
+	@curl -s https://raw.githubusercontent.com/launchdarkly/sdk-test-harness/v3.0.0-alpha.6/downloader/run.sh \
+      | VERSION=v3.0.0-alpha.6 PARAMS="-url http://localhost:$(TEST_SERVICE_PORT) -debug -stop-service-at-end -skip-from=$(SUPPRESSION_FILE_FDV2) $(TEST_HARNESS_PARAMS_V3)" sh
 
 contract-tests: build-contract-tests start-contract-test-service-bg run-contract-tests
 

--- a/lib/sdk/server/contract-tests/service/src/main/java/sdktest/Representations.java
+++ b/lib/sdk/server/contract-tests/service/src/main/java/sdktest/Representations.java
@@ -136,6 +136,12 @@ public abstract class Representations {
     SdkConfigDataInitializerParams[] initializers;
     /** List of synchronizers (matches servicedef DataSystem.Synchronizers). */
     SdkConfigSynchronizerParams[] synchronizers;
+    /**
+     * Configuration for the FDv1 fallback synchronizer engaged in response to a
+     * server-directed FDv1 Fallback Directive. Distinct from the FDv2 synchronizer chain
+     * above; matches servicedef DataSystem.FDv1Fallback.
+     */
+    SdkConfigPollingParams fdv1Fallback;
     String payloadFilter;
   }
 

--- a/lib/sdk/server/contract-tests/service/src/main/java/sdktest/SdkClientEntity.java
+++ b/lib/sdk/server/contract-tests/service/src/main/java/sdktest/SdkClientEntity.java
@@ -33,8 +33,6 @@ import com.launchdarkly.sdk.server.integrations.FDv2PollingInitializerBuilder;
 import com.launchdarkly.sdk.server.integrations.FDv2PollingSynchronizerBuilder;
 import com.launchdarkly.sdk.server.integrations.FDv2StreamingSynchronizerBuilder;
 import com.launchdarkly.sdk.server.interfaces.BigSegmentStoreStatusProvider;
-import com.launchdarkly.sdk.server.subsystems.ComponentConfigurer;
-import com.launchdarkly.sdk.server.subsystems.DataSource;
 import com.launchdarkly.sdk.server.subsystems.DataSourceBuilder;
 import com.launchdarkly.sdk.server.datasources.Initializer;
 import com.launchdarkly.sdk.server.datasources.Synchronizer;
@@ -570,20 +568,23 @@ public class SdkClientEntity {
         }
       }
 
-      // Configure FDv1 fallback synchronizer (pick first polling, else first synchronizer)
-      SdkConfigSynchronizerParams fallbackSynchronizer =
-          selectFallbackSynchronizer(params.dataSystem.synchronizers);
-      if (fallbackSynchronizer != null) {
-        // Set global polling endpoints if the fallback synchronizer has polling with custom base URI
-        if (fallbackSynchronizer.polling != null &&
-            fallbackSynchronizer.polling.baseUri != null) {
-          endpoints.polling(fallbackSynchronizer.polling.baseUri);
+      // Configure the FDv1 fallback synchronizer. This is engaged only when the server returns
+      // the X-LD-FD-Fallback directive; it lives outside the FDv2 Primary/Fallback synchronizer
+      // chain configured above. The test harness sends this as a dedicated top-level field --
+      // do not infer it from the FDv2 synchronizer list.
+      if (params.dataSystem.fdv1Fallback != null) {
+        SdkConfigPollingParams fdv1Params = params.dataSystem.fdv1Fallback;
+        if (fdv1Params.baseUri != null) {
+          endpoints.polling(fdv1Params.baseUri);
         }
-
-        // Create and configure FDv1 fallback
-        ComponentConfigurer<DataSource> fdv1Fallback =
-            createFDv1FallbackSynchronizer(fallbackSynchronizer);
-        dataSystemBuilder.fDv1FallbackSynchronizer(fdv1Fallback);
+        PollingDataSourceBuilder fdv1Polling = Components.pollingDataSource();
+        if (fdv1Params.pollIntervalMs != null) {
+          fdv1Polling.pollInterval(Duration.ofMillis(fdv1Params.pollIntervalMs));
+        }
+        if (params.dataSystem.payloadFilter != null && !params.dataSystem.payloadFilter.isEmpty()) {
+          fdv1Polling.payloadFilter(params.dataSystem.payloadFilter);
+        }
+        dataSystemBuilder.fDv1FallbackSynchronizer(fdv1Polling);
       }
 
       builder.dataSystem(dataSystemBuilder);
@@ -625,47 +626,4 @@ public class SdkClientEntity {
     return null;
   }
 
-  /**
-   * Selects the best synchronizer configuration to use for FDv1 fallback.
-   * Prefers the first polling synchronizer in the list, otherwise the first synchronizer.
-   */
-  private static SdkConfigSynchronizerParams selectFallbackSynchronizer(
-      SdkConfigSynchronizerParams[] synchronizers) {
-    if (synchronizers == null || synchronizers.length == 0) {
-      return null;
-    }
-    // Prefer first polling synchronizer (FDv1 fallback is polling-based)
-    for (SdkConfigSynchronizerParams sync : synchronizers) {
-      if (sync.polling != null) {
-        return sync;
-      }
-    }
-    // Otherwise use first synchronizer (streaming; FDv1 will use default polling config)
-    return synchronizers[0];
-  }
-
-  /**
-   * Creates the FDv1 fallback synchronizer based on the selected synchronizer config.
-   * FDv1 fallback is always polling-based and uses the global service endpoints configuration.
-   */
-  private static ComponentConfigurer<DataSource> createFDv1FallbackSynchronizer(
-      SdkConfigSynchronizerParams synchronizer) {
-
-    // FDv1 fallback is always polling-based
-    PollingDataSourceBuilder fdv1Polling = Components.pollingDataSource();
-
-    // Configure polling interval if the synchronizer has polling configuration
-    if (synchronizer.polling != null) {
-      if (synchronizer.polling.pollIntervalMs != null) {
-        fdv1Polling.pollInterval(Duration.ofMillis(synchronizer.polling.pollIntervalMs));
-      }
-      // Note: FDv1 polling doesn't support per-source service endpoints override,
-      // so it will use the global service endpoints configuration (which is set
-      // by the caller before this method is invoked)
-    }
-    // If streaming synchronizer, use default polling interval
-    // (no additional configuration needed)
-
-    return fdv1Polling;
-  }
 }

--- a/lib/sdk/server/contract-tests/service/src/main/java/sdktest/TestService.java
+++ b/lib/sdk/server/contract-tests/service/src/main/java/sdktest/TestService.java
@@ -41,7 +41,8 @@ public class TestService {
     "service-endpoints",
     "strongly-typed",
     "tags",
-    "server-side-polling"
+    "server-side-polling",
+    "fdv1-fallback"
   };
 
   static final Gson gson = new GsonBuilder().serializeNulls().create();

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -133,8 +133,26 @@ class FDv2DataSource implements DataSource {
                 return;
             }
 
+            InitializerOutcome initializerOutcome = InitializerOutcome.completed();
             if (sourceManager.hasInitializers()) {
-                runInitializers();
+                initializerOutcome = runInitializers();
+            }
+
+            // If an initializer signalled FDv1 fallback, switch to the FDv1 synchronizer
+            // (if configured) or transition to OFF. This takes precedence over the standard
+            // synchronizer chain -- the FDv2 synchronizers are not given a chance to run.
+            if (initializerOutcome.fallbackToFDv1) {
+                if (sourceManager.hasFDv1Fallback()) {
+                    logger.warn("Initializer requested fallback to FDv1; switching to FDv1 fallback synchronizer.");
+                    sourceManager.fdv1Fallback();
+                } else {
+                    logger.warn("Initializer requested fallback to FDv1, but no FDv1 fallback synchronizer is configured.");
+                    dataSourceUpdates.updateStatus(
+                        DataSourceStatusProvider.State.OFF,
+                        initializerOutcome.errorInfo);
+                    startFuture.complete(false);
+                    return;
+                }
             }
 
             if(!sourceManager.hasAvailableSynchronizers()) {
@@ -164,7 +182,18 @@ class FDv2DataSource implements DataSource {
         runThread.start();
     }
 
-    private void runInitializers() {
+    /**
+     * Runs the configured initializers in order until one succeeds, the list is exhausted,
+     * or one signals an FDv1 fallback directive. Returns an {@link InitializerOutcome}
+     * describing whether the caller should switch to the FDv1 fallback synchronizer.
+     * <p>
+     * If an initializer's result carries {@link FDv2SourceResult#isFdv1Fallback()}, any
+     * accompanying payload is applied first so evaluations can serve the server-provided
+     * data while the FDv1 synchronizer is brought up. When the directive accompanies an
+     * error result the underlying error is preserved on the returned outcome so the
+     * caller can surface it on a subsequent OFF status (when no fallback is configured).
+     */
+    private InitializerOutcome runInitializers() {
         boolean anyDataReceived = false;
         Initializer initializer = sourceManager.getNextInitializerAndSetActive();
         while (initializer != null) {
@@ -172,16 +201,20 @@ class FDv2DataSource implements DataSource {
             logger.info("Initializer '{}' is starting.", initializerName);
             try {
                 try (FDv2SourceResult result = initializer.run().get()) {
+                    DataSourceStatusProvider.ErrorInfo fallbackErrorInfo = null;
                     switch (result.getResultType()) {
                         case CHANGE_SET:
                             dataSourceUpdates.apply(result.getChangeSet());
                             anyDataReceived = true;
                             logger.info("Initialized via '{}'.", initializerName);
                             if (!result.getChangeSet().getSelector().isEmpty()) {
-                                // We received data with a selector, so we end the initialization process.
+                                // We received data with a selector, so initialization is complete.
                                 dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
                                 startFuture.complete(true);
-                                return;
+                                if (result.isFdv1Fallback()) {
+                                    return InitializerOutcome.fallbackToFDv1(null);
+                                }
+                                return InitializerOutcome.completed();
                             }
                             break;
                         case STATUS:
@@ -192,6 +225,7 @@ class FDv2DataSource implements DataSource {
                                     logger.warn("Initializer '{}' failed: {}",
                                         initializerName,
                                         detailForError(status.getErrorInfo()));
+                                    fallbackErrorInfo = status.getErrorInfo();
                                     // The data source updates handler will filter the state during initializing, but this
                                     // will make the error information available.
                                     dataSourceUpdates.updateStatus(
@@ -207,6 +241,19 @@ class FDv2DataSource implements DataSource {
                                     break;
                             }
                             break;
+                    }
+                    // FDv1 fallback may ride along on either a successful CHANGE_SET (with no
+                    // selector, so initialization is incomplete) or on a STATUS error result.
+                    // In either case, the SDK must halt the FDv2 chain immediately and switch
+                    // to the FDv1 fallback synchronizer.
+                    if (result.isFdv1Fallback()) {
+                        if (anyDataReceived) {
+                            // Treat data without a selector as enough to consider ourselves initialized
+                            // before handing off to the FDv1 synchronizer.
+                            dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
+                            startFuture.complete(true);
+                        }
+                        return InitializerOutcome.fallbackToFDv1(fallbackErrorInfo);
                     }
                 }
             } catch (ExecutionException | InterruptedException | CancellationException e) {
@@ -233,6 +280,29 @@ class FDv2DataSource implements DataSource {
         }
         // If no data was received, then it is possible initialization will complete from synchronizers, so we give
         // them an opportunity to run before reporting any issues.
+        return InitializerOutcome.completed();
+    }
+
+    /**
+     * Outcome of {@link #runInitializers()} relaying whether the SDK should perform a
+     * server-directed FDv1 fallback before the synchronizer phase begins.
+     */
+    private static final class InitializerOutcome {
+        final boolean fallbackToFDv1;
+        final DataSourceStatusProvider.ErrorInfo errorInfo;
+
+        private InitializerOutcome(boolean fallbackToFDv1, DataSourceStatusProvider.ErrorInfo errorInfo) {
+            this.fallbackToFDv1 = fallbackToFDv1;
+            this.errorInfo = errorInfo;
+        }
+
+        static InitializerOutcome completed() {
+            return new InitializerOutcome(false, null);
+        }
+
+        static InitializerOutcome fallbackToFDv1(DataSourceStatusProvider.ErrorInfo errorInfo) {
+            return new InitializerOutcome(true, errorInfo);
+        }
     }
 
     /**

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -457,11 +457,11 @@ class FDv2DataSource implements DataSource {
                                         logger.info("Falling back to an FDv1 fallback synchronizer.");
                                         running = false;
                                     } else {
-                                        // Spec 1.6.3(4): when the directive is signalled but no FDv1
-                                        // fallback synchronizer is configured, halt the data system
-                                        // entirely. Block the current synchronizer so it cannot be
-                                        // selected again, surface OFF with the most recent error info
-                                        // (if any), and exit the synchronizer loop terminally.
+                                        // When the directive is signalled but no FDv1 fallback synchronizer
+                                        // is configured, halt the data system entirely. Block the current
+                                        // synchronizer so it cannot be selected again, surface OFF with the
+                                        // most recent error info (if any), and exit the synchronizer loop
+                                        // terminally.
                                         logger.warn(
                                             "Synchronizer '{}' requested FDv1 fallback, but no FDv1 fallback synchronizer is configured; halting the data system.",
                                             synchronizer.name()

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -138,13 +138,15 @@ class FDv2DataSource implements DataSource {
                 initializerOutcome = runInitializers();
             }
 
-            // If an initializer signalled FDv1 fallback, switch to the FDv1 synchronizer
-            // (if configured) or transition to OFF. This takes precedence over the standard
+            // If an initializer signalled FDv1 fallback, block every FDv2 synchronizer in
+            // one shot via fdv1Fallback() (which also unblocks the FDv1 fallback
+            // synchronizer, if one is configured). If FDv1 is configured we hand off to it;
+            // otherwise we halt the data system. This takes precedence over the standard
             // synchronizer chain -- the FDv2 synchronizers are not given a chance to run.
             if (initializerOutcome.fallbackToFDv1) {
+                sourceManager.fdv1Fallback();
                 if (sourceManager.hasFDv1Fallback()) {
                     logger.warn("Initializer requested fallback to FDv1; switching to FDv1 fallback synchronizer.");
-                    sourceManager.fdv1Fallback();
                 } else {
                     logger.warn("Initializer requested fallback to FDv1, but no FDv1 fallback synchronizer is configured.");
                     dataSourceUpdates.updateStatus(

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -196,7 +196,6 @@ class FDv2DataSource implements DataSource {
      * caller can surface it on a subsequent OFF status (when no fallback is configured).
      */
     private InitializerOutcome runInitializers() {
-        boolean anyDataReceived = false;
         Initializer initializer = sourceManager.getNextInitializerAndSetActive();
         while (initializer != null) {
             String initializerName = initializer.name();
@@ -207,10 +206,12 @@ class FDv2DataSource implements DataSource {
                     switch (result.getResultType()) {
                         case CHANGE_SET:
                             dataSourceUpdates.apply(result.getChangeSet());
-                            anyDataReceived = true;
                             logger.info("Initialized via '{}'.", initializerName);
                             if (!result.getChangeSet().getSelector().isEmpty()) {
-                                // We received data with a selector, so initialization is complete.
+                                // A defined selector marks initialization complete -- match Go/Python/Ruby
+                                // behavior. A selectorless basis is applied so evaluations can serve it,
+                                // but does not yet mark the data source VALID; the synchronizer phase
+                                // (or FDv1 fallback) is responsible for the eventual VALID transition.
                                 dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
                                 startFuture.complete(true);
                                 if (result.isFdv1Fallback()) {
@@ -247,14 +248,9 @@ class FDv2DataSource implements DataSource {
                     // FDv1 fallback may ride along on either a successful CHANGE_SET (with no
                     // selector, so initialization is incomplete) or on a STATUS error result.
                     // In either case, the SDK must halt the FDv2 chain immediately and switch
-                    // to the FDv1 fallback synchronizer.
+                    // to the FDv1 fallback synchronizer; the eventual VALID status will come
+                    // from the FDv1 synchronizer once it serves a selectorful payload.
                     if (result.isFdv1Fallback()) {
-                        if (anyDataReceived) {
-                            // Treat data without a selector as enough to consider ourselves initialized
-                            // before handing off to the FDv1 synchronizer.
-                            dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
-                            startFuture.complete(true);
-                        }
                         return InitializerOutcome.fallbackToFDv1(fallbackErrorInfo);
                     }
                 }
@@ -274,14 +270,10 @@ class FDv2DataSource implements DataSource {
             }
             initializer = sourceManager.getNextInitializerAndSetActive();
         }
-        // We received data without a selector, and we have exhausted initializers, so we are going to
-        // consider ourselves initialized.
-        if (anyDataReceived) {
-            dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
-            startFuture.complete(true);
-        }
-        // If no data was received, then it is possible initialization will complete from synchronizers, so we give
-        // them an opportunity to run before reporting any issues.
+        // No initializer produced a selectorful basis. Initialization is not yet complete --
+        // leave it to the synchronizer phase (or FDv1 fallback) to drive the eventual VALID
+        // transition. Any selectorless basis has already been applied to the store above so
+        // evaluations can serve it during the gap.
         return InitializerOutcome.completed();
     }
 

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -449,26 +449,27 @@ class FDv2DataSource implements DataSource {
                                         }
                                         break;
                                 }
-                                // We have been requested to fall back to FDv1. We handle whatever message was associated,
-                                // close the synchronizer, and then fallback. An FDv1 fallback synchronizer
-                                // requesting another fallback is ignored (shouldn't happen in practice).
+                                // We have been requested to fall back to FDv1. Block every FDv2
+                                // synchronizer in one shot via fdv1Fallback() (which also unblocks the
+                                // FDv1 fallback synchronizer, if one is configured). If FDv1 is
+                                // configured we hand off to it; otherwise we halt the data system.
+                                // An FDv1 fallback synchronizer asking to fall back again is ignored
+                                // -- shouldn't happen in practice.
                                 if (result.isFdv1Fallback()
                                     && !sourceManager.isCurrentSynchronizerFDv1Fallback()) {
+                                    sourceManager.fdv1Fallback();
                                     if (sourceManager.hasFDv1Fallback()) {
-                                        sourceManager.fdv1Fallback();
                                         logger.info("Falling back to an FDv1 fallback synchronizer.");
                                         running = false;
                                     } else {
                                         // When the directive is signalled but no FDv1 fallback synchronizer
-                                        // is configured, halt the data system entirely. Block the current
-                                        // synchronizer so it cannot be selected again, surface OFF with the
-                                        // most recent error info (if any), and exit the synchronizer loop
-                                        // terminally.
+                                        // is configured, halt the data system entirely. Surface OFF with
+                                        // the most recent error info (if any) and exit the synchronizer
+                                        // loop terminally.
                                         logger.warn(
                                             "Synchronizer '{}' requested FDv1 fallback, but no FDv1 fallback synchronizer is configured; halting the data system.",
                                             synchronizer.name()
                                         );
-                                        sourceManager.blockCurrentSynchronizer();
                                         DataSourceStatusProvider.ErrorInfo offError =
                                             result.getStatus() != null ? result.getStatus().getErrorInfo() : null;
                                         dataSourceUpdates.updateStatus(

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -196,6 +196,7 @@ class FDv2DataSource implements DataSource {
      * caller can surface it on a subsequent OFF status (when no fallback is configured).
      */
     private InitializerOutcome runInitializers() {
+        boolean anyDataReceived = false;
         Initializer initializer = sourceManager.getNextInitializerAndSetActive();
         while (initializer != null) {
             String initializerName = initializer.name();
@@ -206,12 +207,15 @@ class FDv2DataSource implements DataSource {
                     switch (result.getResultType()) {
                         case CHANGE_SET:
                             dataSourceUpdates.apply(result.getChangeSet());
+                            anyDataReceived = true;
                             logger.info("Initialized via '{}'.", initializerName);
                             if (!result.getChangeSet().getSelector().isEmpty()) {
                                 // A defined selector marks initialization complete -- match Go/Python/Ruby
                                 // behavior. A selectorless basis is applied so evaluations can serve it,
-                                // but does not yet mark the data source VALID; the synchronizer phase
-                                // (or FDv1 fallback) is responsible for the eventual VALID transition.
+                                // and once the initializer chain is fully exhausted that applied data is
+                                // also enough to consider initialization complete (see the post-loop
+                                // block below); but mid-chain we don't yet flip to VALID, so a later
+                                // initializer can still produce a selectorful basis if one is available.
                                 dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
                                 startFuture.complete(true);
                                 if (result.isFdv1Fallback()) {
@@ -270,10 +274,16 @@ class FDv2DataSource implements DataSource {
             }
             initializer = sourceManager.getNextInitializerAndSetActive();
         }
-        // No initializer produced a selectorful basis. Initialization is not yet complete --
-        // leave it to the synchronizer phase (or FDv1 fallback) to drive the eventual VALID
-        // transition. Any selectorless basis has already been applied to the store above so
-        // evaluations can serve it during the gap.
+        // No initializer produced a selectorful basis, but at least one initializer applied
+        // a selectorless basis. Treat that as enough to consider the data system initialized
+        // now that the entire initializer chain is exhausted -- evaluations can serve the
+        // applied data, and the synchronizer phase (when configured) will continue from
+        // there. Without this, an SDK configured with only selectorless initializers and no
+        // synchronizer would never transition out of INITIALIZING.
+        if (anyDataReceived) {
+            dataSourceUpdates.updateStatus(DataSourceStatusProvider.State.VALID, null);
+            startFuture.complete(true);
+        }
         return InitializerOutcome.completed();
     }
 

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/FDv2DataSource.java
@@ -167,11 +167,13 @@ class FDv2DataSource implements DataSource {
                 return;
             }
 
-            runSynchronizers();
+            boolean haltedByDirective = runSynchronizers();
 
-            // If we had synchronizers, and we ran out of them, and we aren't shutting down, then that was unexpected,
-            // and we will report it.
-            maybeReportUnexpectedExhaustion("All data source acquisition methods have been exhausted.");
+            if (!haltedByDirective) {
+                // If we had synchronizers, and we ran out of them, and we aren't shutting down, then that was unexpected,
+                // and we will report it.
+                maybeReportUnexpectedExhaustion("All data source acquisition methods have been exhausted.");
+            }
 
             // If we had initialized at some point, then the future will already be complete and this will be ignored.
             startFuture.complete(false);
@@ -329,7 +331,17 @@ class FDv2DataSource implements DataSource {
         return conditionFactories.stream().map(ConditionFactory::build).collect(Collectors.toList());
     }
 
-    private void runSynchronizers() {
+    /**
+     * Runs the configured synchronizers, falling back / recovering as conditions allow,
+     * until the list is exhausted, the data source is closed, or a server-directed FDv1
+     * fallback halts the data system.
+     *
+     * @return true when {@code runSynchronizers} halted in response to a server-directed
+     *         FDv1 fallback directive that could not be satisfied (no FDv1 fallback
+     *         synchronizer configured) -- the caller should NOT report exhaustion in
+     *         that case because OFF has already been published with a specific error.
+     */
+    private boolean runSynchronizers() {
         // When runSynchronizers exists, no matter how it exits, the synchronizerStateManager will be closed.
         try {
             Synchronizer synchronizer = sourceManager.getNextAvailableSynchronizerAndSetActive();
@@ -413,7 +425,7 @@ class FDv2DataSource implements DataSource {
                                                 );
                                                 // We should be overall shutting down.
                                                 logger.debug("Synchronizer shutdown.");
-                                                return;
+                                                return false;
                                             case TERMINAL_ERROR:
                                                 maybeLogSynchronizerStatusChange(
                                                     synchronizer.name(),
@@ -436,18 +448,33 @@ class FDv2DataSource implements DataSource {
                                         break;
                                 }
                                 // We have been requested to fall back to FDv1. We handle whatever message was associated,
-                                // close the synchronizer, and then fallback.
-                                // Only trigger fallback if we're not already running the FDv1 fallback synchronizer.
-                                if (
-                                    result.isFdv1Fallback() &&
-                                        sourceManager.hasFDv1Fallback() &&
-                                        // This shouldn't happen in practice, an FDv1 source shouldn't request fallback
-                                        // to FDv1. But if it does, then we will discard its request.
-                                        !sourceManager.isCurrentSynchronizerFDv1Fallback()
-                                ) {
-                                    sourceManager.fdv1Fallback();
-                                    logger.info("Falling back to an FDv1 fallback synchronizer.");
-                                    running = false;
+                                // close the synchronizer, and then fallback. An FDv1 fallback synchronizer
+                                // requesting another fallback is ignored (shouldn't happen in practice).
+                                if (result.isFdv1Fallback()
+                                    && !sourceManager.isCurrentSynchronizerFDv1Fallback()) {
+                                    if (sourceManager.hasFDv1Fallback()) {
+                                        sourceManager.fdv1Fallback();
+                                        logger.info("Falling back to an FDv1 fallback synchronizer.");
+                                        running = false;
+                                    } else {
+                                        // Spec 1.6.3(4): when the directive is signalled but no FDv1
+                                        // fallback synchronizer is configured, halt the data system
+                                        // entirely. Block the current synchronizer so it cannot be
+                                        // selected again, surface OFF with the most recent error info
+                                        // (if any), and exit the synchronizer loop terminally.
+                                        logger.warn(
+                                            "Synchronizer '{}' requested FDv1 fallback, but no FDv1 fallback synchronizer is configured; halting the data system.",
+                                            synchronizer.name()
+                                        );
+                                        sourceManager.blockCurrentSynchronizer();
+                                        DataSourceStatusProvider.ErrorInfo offError =
+                                            result.getStatus() != null ? result.getStatus().getErrorInfo() : null;
+                                        dataSourceUpdates.updateStatus(
+                                            DataSourceStatusProvider.State.OFF,
+                                            offError);
+                                        startFuture.complete(false);
+                                        return true;
+                                    }
                                 }
                             }
                         }
@@ -478,6 +505,7 @@ class FDv2DataSource implements DataSource {
         } finally {
             sourceManager.close();
         }
+        return false;
     }
 
     private static String detailForError(DataSourceStatusProvider.ErrorInfo errorInfo) {

--- a/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
+++ b/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
@@ -1939,7 +1939,7 @@ public class FDv2DataSourceTest extends BaseTest {
     }
 
     @Test
-    public void initializerChangeSetWithoutSelectorDoesNotCompleteWithoutSynchronizer() throws Exception {
+    public void initializerChangeSetWithoutSelectorCompletesIfLastInitializer() throws Exception {
         executor = Executors.newScheduledThreadPool(2);
         MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
 
@@ -1956,17 +1956,19 @@ public class FDv2DataSourceTest extends BaseTest {
         FDv2DataSource dataSource = new FDv2DataSource(initializers, synchronizers, null, sink, Thread.NORM_PRIORITY, logger, executor, 120, 300);
         resourcesToClose.add(dataSource);
 
-        dataSource.start();
+        Future<Void> startFuture = dataSource.start();
+        startFuture.get(2, TimeUnit.SECONDS);
 
-        // A selectorless basis was applied to the store (so evaluations can serve it),
-        // but the data source must NOT mark itself initialized -- only a basis with a
-        // defined selector can drive the VALID transition. This matches the cross-SDK
-        // contract (Go/Python/Ruby). With no synchronizers configured the source
-        // exhausts and transitions to OFF.
-        DataSourceStatusProvider.State status = sink.awaitStatus(2, TimeUnit.SECONDS);
-        assertEquals(DataSourceStatusProvider.State.OFF, status);
-        assertFalse(dataSource.isInitialized());
+        // A single initializer applied a selectorless basis and there are no synchronizers,
+        // so once the initializer chain exhausts the applied data is enough to mark the
+        // data source VALID and complete startFuture.
+        List<DataSourceStatusProvider.State> statuses = sink.awaitStatuses(1, 2, TimeUnit.SECONDS);
+        assertEquals("Should receive 1 status update", 1, statuses.size());
+        assertEquals(DataSourceStatusProvider.State.VALID, statuses.get(0));
+
+        assertTrue(dataSource.isInitialized());
         assertEquals(1, sink.getApplyCount());
+        assertEquals(DataSourceStatusProvider.State.VALID, sink.getLastState());
     }
 
     @Test
@@ -2188,10 +2190,8 @@ public class FDv2DataSourceTest extends BaseTest {
         executor = Executors.newScheduledThreadPool(2);
         MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
 
-        // Initializer returns a basis WITH a defined selector -- this is what the
-        // cross-SDK contract requires for the VALID transition.
         CompletableFuture<FDv2SourceResult> initializerFuture = CompletableFuture.completedFuture(
-            FDv2SourceResult.changeSet(makeChangeSet(true), false)
+            FDv2SourceResult.changeSet(makeChangeSet(false), false)
         );
 
         ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
@@ -2952,55 +2952,6 @@ public class FDv2DataSourceTest extends BaseTest {
         // is initialized iff that transition has been observed.
         assertEquals(DataSourceStatusProvider.State.VALID, sink.getLastState());
         assertTrue("isInitialized() must be true after FDv1 served selectorful basis",
-            dataSource.isInitialized());
-    }
-
-    // Tighter spec-alignment check: an initializer returning a selectorless basis (without the
-    // FDv1 directive) must NOT mark the data source VALID on its own. The synchronizer phase
-    // is responsible for the eventual VALID transition once a selectorful basis arrives. This
-    // matches Go/Python/Ruby; Java previously marked VALID prematurely on `anyDataReceived`.
-    @Test
-    public void initializerSelectorlessBasisDoesNotMarkValid() throws Exception {
-        executor = Executors.newScheduledThreadPool(2);
-        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
-
-        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
-            FDv2SourceResult.changeSet(makeChangeSet(false), false)
-        );
-        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
-            () -> new MockInitializer(initFuture)
-        );
-
-        // Synchronizer that never publishes a result -- so VALID would only come from the
-        // initializer if Java were (incorrectly) marking VALID on selectorless data.
-        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
-            () -> new MockQueuedSynchronizer(new LinkedBlockingQueue<>())
-        );
-
-        FDv2DataSource dataSource = new FDv2DataSource(
-            initializers,
-            synchronizers,
-            null,
-            sink,
-            Thread.NORM_PRIORITY,
-            logger,
-            executor,
-            120,
-            300
-        );
-        resourcesToClose.add(dataSource);
-
-        // Wait for the initializer's apply to happen so we know the run loop reached the
-        // post-initializer phase.
-        dataSource.start();
-        sink.awaitApplyCount(1, 2, TimeUnit.SECONDS);
-        assertEquals("Initializer's selectorless basis must still be applied to the store",
-            1, sink.getApplyCount());
-
-        // The data source must not be VALID, and isInitialized() must be false.
-        assertNotEquals("Selectorless initializer basis must not transition the data source to VALID",
-            DataSourceStatusProvider.State.VALID, sink.getLastState());
-        assertFalse("isInitialized() must be false until a selectorful basis is applied",
             dataSource.isInitialized());
     }
 

--- a/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
+++ b/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
@@ -2679,6 +2679,235 @@ public class FDv2DataSourceTest extends BaseTest {
         assertNull("FDv1 fallback should only be called once", secondCall);
     }
 
+    // ============================================================================
+    // FDv1 Fallback (Initializer Phase) Tests
+    // ============================================================================
+
+    // An initializer that returns a successful payload with the FDv1 fallback flag must
+    // (1) apply the payload, then (2) hand off directly to the FDv1 fallback synchronizer
+    // without giving any of the configured FDv2 synchronizers a chance to run.
+    @Test
+    public void fdv1FallbackOnInitializerSuccessAppliesPayloadAndSwitches() throws Exception {
+        executor = Executors.newScheduledThreadPool(2);
+        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
+
+        // Initializer returns a payload with a selector AND the FDv1 fallback signal.
+        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
+            FDv2SourceResult.changeSet(makeChangeSet(true), true)
+        );
+        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
+            () -> new MockInitializer(initFuture)
+        );
+
+        AtomicBoolean fdv2SyncCalled = new AtomicBoolean(false);
+        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
+            () -> {
+                fdv2SyncCalled.set(true);
+                return new MockQueuedSynchronizer(new LinkedBlockingQueue<>());
+            }
+        );
+
+        BlockingQueue<FDv2SourceResult> fdv1SyncResults = new LinkedBlockingQueue<>();
+        fdv1SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), false));
+
+        BlockingQueue<Boolean> fdv1CalledQueue = new LinkedBlockingQueue<>();
+        FDv2DataSource.DataSourceFactory<Synchronizer> fdv1Fallback = () -> {
+            fdv1CalledQueue.offer(true);
+            return new MockQueuedSynchronizer(fdv1SyncResults);
+        };
+
+        FDv2DataSource dataSource = new FDv2DataSource(
+            initializers,
+            synchronizers,
+            fdv1Fallback,
+            sink,
+            Thread.NORM_PRIORITY,
+            logger,
+            executor,
+            120,
+            300
+        );
+        resourcesToClose.add(dataSource);
+
+        dataSource.start().get(2, TimeUnit.SECONDS);
+
+        // Initializer payload was applied.
+        sink.awaitApplyCount(1, 2, TimeUnit.SECONDS);
+        assertTrue("Initializer payload should be applied before fallback", sink.getApplyCount() >= 1);
+
+        // FDv1 fallback was activated.
+        Boolean fdv1Called = fdv1CalledQueue.poll(2, TimeUnit.SECONDS);
+        assertNotNull("FDv1 fallback should be activated by initializer-phase directive", fdv1Called);
+
+        // FDv2 synchronizer was never asked to run.
+        assertFalse("FDv2 synchronizers must be skipped after initializer-phase fallback",
+            fdv2SyncCalled.get());
+    }
+
+    // An initializer that fails with the FDv1 fallback flag (e.g. 500 + header) must hand off
+    // to the FDv1 fallback synchronizer without trying FDv2 synchronizers.
+    @Test
+    public void fdv1FallbackOnInitializerErrorSwitchesToFDv1() throws Exception {
+        executor = Executors.newScheduledThreadPool(2);
+        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
+
+        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
+            FDv2SourceResult.terminalError(
+                new DataSourceStatusProvider.ErrorInfo(
+                    DataSourceStatusProvider.ErrorKind.ERROR_RESPONSE,
+                    500,
+                    "fallback requested",
+                    Instant.now()
+                ),
+                true
+            )
+        );
+        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
+            () -> new MockInitializer(initFuture)
+        );
+
+        AtomicBoolean fdv2SyncCalled = new AtomicBoolean(false);
+        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
+            () -> {
+                fdv2SyncCalled.set(true);
+                return new MockQueuedSynchronizer(new LinkedBlockingQueue<>());
+            }
+        );
+
+        BlockingQueue<FDv2SourceResult> fdv1SyncResults = new LinkedBlockingQueue<>();
+        fdv1SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), false));
+
+        BlockingQueue<Boolean> fdv1CalledQueue = new LinkedBlockingQueue<>();
+        FDv2DataSource.DataSourceFactory<Synchronizer> fdv1Fallback = () -> {
+            fdv1CalledQueue.offer(true);
+            return new MockQueuedSynchronizer(fdv1SyncResults);
+        };
+
+        FDv2DataSource dataSource = new FDv2DataSource(
+            initializers,
+            synchronizers,
+            fdv1Fallback,
+            sink,
+            Thread.NORM_PRIORITY,
+            logger,
+            executor,
+            120,
+            300
+        );
+        resourcesToClose.add(dataSource);
+
+        dataSource.start().get(2, TimeUnit.SECONDS);
+
+        Boolean fdv1Called = fdv1CalledQueue.poll(2, TimeUnit.SECONDS);
+        assertNotNull("FDv1 fallback should be activated even when initializer signals error",
+            fdv1Called);
+        assertFalse("FDv2 synchronizers must be skipped after initializer-phase fallback",
+            fdv2SyncCalled.get());
+    }
+
+    // When an initializer signals FDv1 fallback but no FDv1 synchronizer is configured, the
+    // SDK must transition the data source status to OFF -- not stay stuck at INITIALIZING --
+    // and surface the underlying initializer error so monitors can see why.
+    @Test
+    public void fdv1FallbackOnInitializerWithoutFDv1ConfiguredTransitionsToOff() throws Exception {
+        executor = Executors.newScheduledThreadPool(1);
+        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
+
+        DataSourceStatusProvider.ErrorInfo initError = new DataSourceStatusProvider.ErrorInfo(
+            DataSourceStatusProvider.ErrorKind.ERROR_RESPONSE,
+            500,
+            "fallback requested without fallback configured",
+            Instant.now()
+        );
+        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
+            FDv2SourceResult.terminalError(initError, true)
+        );
+        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
+            () -> new MockInitializer(initFuture)
+        );
+
+        AtomicBoolean fdv2SyncCalled = new AtomicBoolean(false);
+        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
+            () -> {
+                fdv2SyncCalled.set(true);
+                return new MockQueuedSynchronizer(new LinkedBlockingQueue<>());
+            }
+        );
+
+        // No FDv1 fallback configured.
+        FDv2DataSource dataSource = new FDv2DataSource(
+            initializers,
+            synchronizers,
+            null,
+            sink,
+            Thread.NORM_PRIORITY,
+            logger,
+            executor,
+            120,
+            300
+        );
+        resourcesToClose.add(dataSource);
+
+        dataSource.start().get(2, TimeUnit.SECONDS);
+
+        // Status must end up OFF (not INITIALIZING) so callers can observe the terminal state.
+        assertEquals(DataSourceStatusProvider.State.OFF, sink.getLastState());
+        assertNotNull("Initializer error should be preserved on the OFF status", sink.getLastError());
+        assertEquals(initError.getKind(), sink.getLastError().getKind());
+        assertEquals(initError.getStatusCode(), sink.getLastError().getStatusCode());
+
+        // FDv2 synchronizers should not run.
+        assertFalse(fdv2SyncCalled.get());
+    }
+
+    // When an initializer returns a successful payload-without-selector AND the FDv1 fallback
+    // flag, the partial payload should still be applied (so evaluations can serve it) and the
+    // SDK should move on to the FDv1 synchronizer rather than scanning further FDv2 sources.
+    @Test
+    public void fdv1FallbackOnInitializerSuccessNoSelectorAppliesPayloadAndSwitches() throws Exception {
+        executor = Executors.newScheduledThreadPool(2);
+        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
+
+        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
+            FDv2SourceResult.changeSet(makeChangeSet(false), true)
+        );
+        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
+            () -> new MockInitializer(initFuture)
+        );
+
+        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of();
+
+        BlockingQueue<FDv2SourceResult> fdv1SyncResults = new LinkedBlockingQueue<>();
+        fdv1SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(true), false));
+
+        BlockingQueue<Boolean> fdv1CalledQueue = new LinkedBlockingQueue<>();
+        FDv2DataSource.DataSourceFactory<Synchronizer> fdv1Fallback = () -> {
+            fdv1CalledQueue.offer(true);
+            return new MockQueuedSynchronizer(fdv1SyncResults);
+        };
+
+        FDv2DataSource dataSource = new FDv2DataSource(
+            initializers,
+            synchronizers,
+            fdv1Fallback,
+            sink,
+            Thread.NORM_PRIORITY,
+            logger,
+            executor,
+            120,
+            300
+        );
+        resourcesToClose.add(dataSource);
+
+        dataSource.start().get(2, TimeUnit.SECONDS);
+
+        // Initializer payload applied (1) + FDv1 follow-up payload applied (2).
+        sink.awaitApplyCount(2, 2, TimeUnit.SECONDS);
+        assertTrue("Both initializer and FDv1 payloads should have been applied",
+            sink.getApplyCount() >= 2);
+        assertNotNull(fdv1CalledQueue.poll(2, TimeUnit.SECONDS));
+    }
+
     @Test
     public void orchestrationLogging_warnsWhenNoInitializersOrSynchronizersConfigured() throws Exception {
         executor = Executors.newScheduledThreadPool(1);

--- a/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
+++ b/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
@@ -2533,7 +2533,7 @@ public class FDv2DataSourceTest extends BaseTest {
 
     // Synchronizer-phase analogue of the initializer halt path: when a synchronizer signals
     // FDv1 fallback but no FDv1 fallback synchronizer is configured, the data system must halt
-    // (transition to OFF, stop building further synchronizers) per Data System spec 1.6.3(4).
+    // (transition to OFF, stop building further synchronizers).
     @Test
     public void fdv1FallbackOnSynchronizerWithoutFDv1ConfiguredHaltsDataSystem() throws Exception {
         executor = Executors.newScheduledThreadPool(2);

--- a/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
+++ b/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
@@ -1939,7 +1939,7 @@ public class FDv2DataSourceTest extends BaseTest {
     }
 
     @Test
-    public void initializerChangeSetWithoutSelectorCompletesIfLastInitializer() throws Exception {
+    public void initializerChangeSetWithoutSelectorDoesNotCompleteWithoutSynchronizer() throws Exception {
         executor = Executors.newScheduledThreadPool(2);
         MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
 
@@ -1956,17 +1956,17 @@ public class FDv2DataSourceTest extends BaseTest {
         FDv2DataSource dataSource = new FDv2DataSource(initializers, synchronizers, null, sink, Thread.NORM_PRIORITY, logger, executor, 120, 300);
         resourcesToClose.add(dataSource);
 
-        Future<Void> startFuture = dataSource.start();
-        startFuture.get(2, TimeUnit.SECONDS);
+        dataSource.start();
 
-        // Expected status: VALID (single initializer without selector completes when it's the last initializer)
-        List<DataSourceStatusProvider.State> statuses = sink.awaitStatuses(1, 2, TimeUnit.SECONDS);
-        assertEquals("Should receive 1 status update", 1, statuses.size());
-        assertEquals(DataSourceStatusProvider.State.VALID, statuses.get(0));
-
-        assertTrue(dataSource.isInitialized());
+        // A selectorless basis was applied to the store (so evaluations can serve it),
+        // but the data source must NOT mark itself initialized -- only a basis with a
+        // defined selector can drive the VALID transition. This matches the cross-SDK
+        // contract (Go/Python/Ruby). With no synchronizers configured the source
+        // exhausts and transitions to OFF.
+        DataSourceStatusProvider.State status = sink.awaitStatus(2, TimeUnit.SECONDS);
+        assertEquals(DataSourceStatusProvider.State.OFF, status);
+        assertFalse(dataSource.isInitialized());
         assertEquals(1, sink.getApplyCount());
-        assertEquals(DataSourceStatusProvider.State.VALID, sink.getLastState());
     }
 
     @Test
@@ -2188,8 +2188,10 @@ public class FDv2DataSourceTest extends BaseTest {
         executor = Executors.newScheduledThreadPool(2);
         MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
 
+        // Initializer returns a basis WITH a defined selector -- this is what the
+        // cross-SDK contract requires for the VALID transition.
         CompletableFuture<FDv2SourceResult> initializerFuture = CompletableFuture.completedFuture(
-            FDv2SourceResult.changeSet(makeChangeSet(false), false)
+            FDv2SourceResult.changeSet(makeChangeSet(true), false)
         );
 
         ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
@@ -2212,8 +2214,6 @@ public class FDv2DataSourceTest extends BaseTest {
         Future<Void> startFuture = dataSource.start();
         startFuture.get(2, TimeUnit.SECONDS);
 
-        // After initializers complete with data (no selector), VALID status is emitted
-        // Since we initialized successfully and there are no synchronizers, we stay VALID
         DataSourceStatusProvider.State status = sink.awaitStatus(2, TimeUnit.SECONDS);
         assertNotNull("Should receive status update", status);
         assertEquals(DataSourceStatusProvider.State.VALID, status);
@@ -2900,6 +2900,9 @@ public class FDv2DataSourceTest extends BaseTest {
     // When an initializer returns a successful payload-without-selector AND the FDv1 fallback
     // flag, the partial payload should still be applied (so evaluations can serve it) and the
     // SDK should move on to the FDv1 synchronizer rather than scanning further FDv2 sources.
+    // Crucially, a selectorless basis must NOT mark the data source VALID -- that transition
+    // belongs to the FDv1 synchronizer once it serves a selectorful payload. Match Go/Python/
+    // Ruby behavior on initialization gating.
     @Test
     public void fdv1FallbackOnInitializerSuccessNoSelectorAppliesPayloadAndSwitches() throws Exception {
         executor = Executors.newScheduledThreadPool(2);
@@ -2914,6 +2917,7 @@ public class FDv2DataSourceTest extends BaseTest {
 
         ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of();
 
+        // FDv1 sync must serve a selectorful basis to move the data source to VALID.
         BlockingQueue<FDv2SourceResult> fdv1SyncResults = new LinkedBlockingQueue<>();
         fdv1SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(true), false));
 
@@ -2938,11 +2942,66 @@ public class FDv2DataSourceTest extends BaseTest {
 
         dataSource.start().get(2, TimeUnit.SECONDS);
 
-        // Initializer payload applied (1) + FDv1 follow-up payload applied (2).
+        // Both payloads applied: the selectorless initializer basis and the selectorful FDv1 basis.
         sink.awaitApplyCount(2, 2, TimeUnit.SECONDS);
         assertTrue("Both initializer and FDv1 payloads should have been applied",
             sink.getApplyCount() >= 2);
         assertNotNull(fdv1CalledQueue.poll(2, TimeUnit.SECONDS));
+
+        // VALID may only come from the FDv1 synchronizer's selectorful basis. The data source
+        // is initialized iff that transition has been observed.
+        assertEquals(DataSourceStatusProvider.State.VALID, sink.getLastState());
+        assertTrue("isInitialized() must be true after FDv1 served selectorful basis",
+            dataSource.isInitialized());
+    }
+
+    // Tighter spec-alignment check: an initializer returning a selectorless basis (without the
+    // FDv1 directive) must NOT mark the data source VALID on its own. The synchronizer phase
+    // is responsible for the eventual VALID transition once a selectorful basis arrives. This
+    // matches Go/Python/Ruby; Java previously marked VALID prematurely on `anyDataReceived`.
+    @Test
+    public void initializerSelectorlessBasisDoesNotMarkValid() throws Exception {
+        executor = Executors.newScheduledThreadPool(2);
+        MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
+
+        CompletableFuture<FDv2SourceResult> initFuture = CompletableFuture.completedFuture(
+            FDv2SourceResult.changeSet(makeChangeSet(false), false)
+        );
+        ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of(
+            () -> new MockInitializer(initFuture)
+        );
+
+        // Synchronizer that never publishes a result -- so VALID would only come from the
+        // initializer if Java were (incorrectly) marking VALID on selectorless data.
+        ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
+            () -> new MockQueuedSynchronizer(new LinkedBlockingQueue<>())
+        );
+
+        FDv2DataSource dataSource = new FDv2DataSource(
+            initializers,
+            synchronizers,
+            null,
+            sink,
+            Thread.NORM_PRIORITY,
+            logger,
+            executor,
+            120,
+            300
+        );
+        resourcesToClose.add(dataSource);
+
+        // Wait for the initializer's apply to happen so we know the run loop reached the
+        // post-initializer phase.
+        dataSource.start();
+        sink.awaitApplyCount(1, 2, TimeUnit.SECONDS);
+        assertEquals("Initializer's selectorless basis must still be applied to the store",
+            1, sink.getApplyCount());
+
+        // The data source must not be VALID, and isInitialized() must be false.
+        assertNotEquals("Selectorless initializer basis must not transition the data source to VALID",
+            DataSourceStatusProvider.State.VALID, sink.getLastState());
+        assertFalse("isInitialized() must be false until a selectorful basis is applied",
+            dataSource.isInitialized());
     }
 
     @Test

--- a/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
+++ b/lib/sdk/server/src/test/java/com/launchdarkly/sdk/server/FDv2DataSourceTest.java
@@ -2531,27 +2531,42 @@ public class FDv2DataSourceTest extends BaseTest {
         assertTrue("Should have at least 2 changesets", sink.getApplyCount() >= 2);
     }
 
+    // Synchronizer-phase analogue of the initializer halt path: when a synchronizer signals
+    // FDv1 fallback but no FDv1 fallback synchronizer is configured, the data system must halt
+    // (transition to OFF, stop building further synchronizers) per Data System spec 1.6.3(4).
     @Test
-    public void fdv1FallbackWithoutConfiguredFallbackIgnoresFlag() throws Exception {
+    public void fdv1FallbackOnSynchronizerWithoutFDv1ConfiguredHaltsDataSystem() throws Exception {
         executor = Executors.newScheduledThreadPool(2);
         MockDataSourceUpdateSink sink = new MockDataSourceUpdateSink();
 
         ImmutableList<FDv2DataSource.DataSourceFactory<Initializer>> initializers = ImmutableList.of();
 
-        // Synchronizer sends result with FDv1 fallback flag
-        BlockingQueue<FDv2SourceResult> fdv2SyncResults = new LinkedBlockingQueue<>();
-        fdv2SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), false));
-        fdv2SyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), true)); // FDv1 fallback flag
+        // First synchronizer sends a normal payload, then a payload with the directive.
+        BlockingQueue<FDv2SourceResult> firstSyncResults = new LinkedBlockingQueue<>();
+        firstSyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), false));
+        firstSyncResults.add(FDv2SourceResult.changeSet(makeChangeSet(false), true));
 
+        AtomicInteger firstSyncBuildCount = new AtomicInteger(0);
+        AtomicBoolean secondSyncCalled = new AtomicBoolean(false);
+
+        // Two synchronizers configured; once the directive halts the data system, neither
+        // should be re-built. The second synchronizer in particular must never run.
         ImmutableList<FDv2DataSource.DataSourceFactory<Synchronizer>> synchronizers = ImmutableList.of(
-            () -> new MockQueuedSynchronizer(fdv2SyncResults)
+            () -> {
+                firstSyncBuildCount.incrementAndGet();
+                return new MockQueuedSynchronizer(firstSyncResults);
+            },
+            () -> {
+                secondSyncCalled.set(true);
+                return new MockQueuedSynchronizer(new LinkedBlockingQueue<>());
+            }
         );
 
-        // No FDv1 fallback configured (null)
+        // No FDv1 fallback configured.
         FDv2DataSource dataSource = new FDv2DataSource(
             initializers,
             synchronizers,
-            null, // No FDv1 fallback
+            null,
             sink,
             Thread.NORM_PRIORITY,
             logger,
@@ -2561,12 +2576,34 @@ public class FDv2DataSourceTest extends BaseTest {
         );
         resourcesToClose.add(dataSource);
 
-        Future<Void> startFuture = dataSource.start();
-        startFuture.get(2, TimeUnit.SECONDS);
+        dataSource.start().get(2, TimeUnit.SECONDS);
 
-        // Should receive both changesets even though fallback flag was set
+        // First payload is applied; the directive-bearing payload is also applied (the SDK
+        // surfaces the data) but no further synchronizers are dialled.
         sink.awaitApplyCount(2, 2, TimeUnit.SECONDS);
-        assertEquals(2, sink.getApplyCount());
+
+        // Status must end up OFF because the directive could not be satisfied.
+        // Poll briefly for the OFF state in case the final transition is observed slightly
+        // after the apply count reaches 2; this keeps the assertion deterministic without
+        // relying on real-time delays.
+        DataSourceStatusProvider.State finalState = null;
+        for (int i = 0; i < 20 && finalState != DataSourceStatusProvider.State.OFF; i++) {
+            DataSourceStatusProvider.State next = sink.awaitStatus(100, TimeUnit.MILLISECONDS);
+            if (next != null) {
+                finalState = next;
+            } else if (sink.getLastState() == DataSourceStatusProvider.State.OFF) {
+                finalState = DataSourceStatusProvider.State.OFF;
+            }
+        }
+        assertEquals("Status should be OFF after directive halts the data system",
+            DataSourceStatusProvider.State.OFF, sink.getLastState());
+
+        // The second synchronizer must never be built.
+        assertFalse("Subsequent synchronizers must not run after directive-induced halt",
+            secondSyncCalled.get());
+        // The first synchronizer should also not be re-built (we should stay halted).
+        assertEquals("First synchronizer should be built exactly once",
+            1, firstSyncBuildCount.get());
     }
 
     @Test


### PR DESCRIPTION
## Summary

- `FDv2DataSource` now honors `X-LD-FD-Fallback: true` during the **initializer phase**: any accompanying payload is applied first, then the loop bails out and either swaps to the configured FDv1 fallback synchronizer or transitions the data source to `OFF` when no fallback is configured. Synchronizer-phase behavior is unchanged.
- Contract test service declares the new `fdv1-fallback` capability and accepts a top-level `dataSystem.fdv1Fallback` config object, wiring it directly to `dataSystemBuilder.fDv1FallbackSynchronizer(...)` instead of inferring the fallback from the last synchronizer entry.
- Bumps the contract-tests pin from `v3.0.0-alpha.3` to `v3.0.0-alpha.6` to pick up the new directive test suite.

Mirrors the Go reference change in [go-server-sdk#365](https://github.com/launchdarkly/go-server-sdk/pull/365) and contract-test wiring in [go-server-sdk#368](https://github.com/launchdarkly/go-server-sdk/pull/368). Spec rationale lives in [sdk-specs#155](https://github.com/launchdarkly/sdk-specs/pull/155); the new harness suite is in [sdk-test-harness#336](https://github.com/launchdarkly/sdk-test-harness/pull/336).

## Test plan

- [x] Existing synchronizer-phase fallback tests stay green.
- [x] New initializer-phase tests cover: success-with-payload, error, no-FDv1-configured, success-no-selector. All deterministic — no real wall clocks or sleeps.
- [x] Full `:lib:sdk:server:test` suite green.
- [ ] Contract-test workflow against `v3.0.0-alpha.6` runs the new "FDv1 Fallback Directive" suite cleanly in CI.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core `FDv2DataSource` orchestration to short-circuit into FDv1 fallback (or OFF) based on initializer results, which can affect client initialization and status transitions across multiple data sources.
> 
> **Overview**
> `FDv2DataSource` now honors the server-directed FDv1 fallback directive during the *initializer phase*: it applies any returned payload, then immediately blocks FDv2 synchronizers and either switches to the configured FDv1 fallback synchronizer or transitions the data source to `OFF` (preserving error info) when no fallback is configured.
> 
> Synchronizer-phase fallback handling is tightened to also halt to `OFF` when the directive is signaled but no FDv1 fallback is configured, and tests are expanded to cover initializer-phase fallback scenarios and the new halt behavior.
> 
> Contract-test wiring is updated to expose a dedicated `dataSystem.fdv1Fallback` config (instead of inferring it from the synchronizer list), advertise a new `fdv1-fallback` capability, and bump the v3 test harness pin to `v3.0.0-alpha.6`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f2d3304cdfba84b1874b0585dbdb4f2b042881f1. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->