### PR TITLE
chore: remove FDv2 pre-release warnings for GA promotion

### DIFF
--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/Components.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/Components.java
@@ -484,10 +484,6 @@ public abstract class Components {
    * Returns a set of builder options for configuring the SDK data system. When the data system configuration
    * is used it overrides {@link LDConfig.Builder#dataSource(ComponentConfigurer)} and
    * {@link LDConfig.Builder#dataStore(ComponentConfigurer)} in the configuration.
-   * <p>
-   * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-   * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-   * </p>
    *
    * @return a configuration builder
    */

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/DataSystem.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/DataSystem.java
@@ -12,9 +12,6 @@ import java.util.concurrent.Future;
  * Internal interface for the data system abstraction.
  * <p>
  * This interface is package-private and should not be used by application code.
- * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
  */
 interface DataSystem {
   /**

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/DataSystemComponents.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/DataSystemComponents.java
@@ -15,10 +15,6 @@ import static com.launchdarkly.sdk.server.ComponentsImpl.toHttpProperties;
 
 /**
  * Components for use with the data system.
- * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
  */
 public final class DataSystemComponents {
 

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/LDConfig.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/LDConfig.java
@@ -421,10 +421,6 @@ public final class LDConfig {
      * When the data system configuration is used it overrides {@link #dataSource(ComponentConfigurer)} and
      * {@link #dataStore(ComponentConfigurer)} in the configuration.
      * <p>
-     * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-     * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
-     * </p>
-     * <p>
      * <b>Example:</b>
      * </p>
      * <pre><code>

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/DataSystemBuilder.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/DataSystemBuilder.java
@@ -11,10 +11,6 @@ import java.util.List;
 
 /**
  * Configuration builder for the SDK's data acquisition and storage strategy.
- * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
  */
 public final class DataSystemBuilder {
 

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/DataSystemModes.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/DataSystemModes.java
@@ -8,10 +8,6 @@ import com.launchdarkly.sdk.server.subsystems.DataSystemConfiguration;
 /**
  * A set of different data system modes which provide pre-configured {@link DataSystemBuilder}s.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
- * <p>
  * This implementation is non-static to allow for easy usage with "Components".
  * Where we can return an instance of this object, and the user can chain into their desired configuration.
  * </p>

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2PollingInitializerBuilder.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2PollingInitializerBuilder.java
@@ -13,10 +13,6 @@ import com.launchdarkly.sdk.server.subsystems.DiagnosticDescription;
 /**
  * Contains methods for configuring the polling initializer.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
- * <p>
  * <b>Example:</b>
  * </p>
  * <pre><code>

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2PollingSynchronizerBuilder.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2PollingSynchronizerBuilder.java
@@ -15,10 +15,6 @@ import java.time.Duration;
 /**
  * Contains methods for configuring the polling synchronizer.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
- * <p>
  * <b>Example:</b>
  * </p>
  * <pre><code>

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2StreamingSynchronizerBuilder.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FDv2StreamingSynchronizerBuilder.java
@@ -15,10 +15,6 @@ import java.time.Duration;
 /**
  * Contains methods for configuring the streaming synchronizer.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
- * <p>
  * <b>Example:</b>
  * </p>
  * <pre><code>

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FileData.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/integrations/FileData.java
@@ -150,10 +150,6 @@ public abstract class FileData {
    * <p>
    * An initializer performs a one-shot load of the file data. This is used with the FDv2 data system
    * for initial data loading.
-   * <p>
-   * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-   * It is in early access. If you want access to this feature please join the EAP.
-   * <a href="https://launchdarkly.com/docs/sdk/features/data-saving-mode">https://launchdarkly.com/docs/sdk/features/data-saving-mode</a>
    *
    * @return a builder for configuring the file data initializer
    */
@@ -166,10 +162,6 @@ public abstract class FileData {
    * <p>
    * A synchronizer loads file data and can watch for changes (if autoUpdate is enabled).
    * This is used with the FDv2 data system for ongoing data synchronization.
-   * <p>
-   * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-   * It is in early access. If you want access to this feature please join the EAP.
-   * <a href="https://launchdarkly.com/docs/sdk/features/data-saving-mode">https://launchdarkly.com/docs/sdk/features/data-saving-mode</a>
    *
    * @return a builder for configuring the file data synchronizer
    */
@@ -181,10 +173,6 @@ public abstract class FileData {
 
   /**
    * Builder for creating an FDv2 {@link Initializer} that loads file data.
-   * <p>
-   * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-   * It is in early access. If you want access to this feature please join the EAP.
-   * <a href="https://launchdarkly.com/docs/sdk/features/data-saving-mode">https://launchdarkly.com/docs/sdk/features/data-saving-mode</a>
    */
   public static final class FileInitializerBuilder implements DataSourceBuilder<Initializer> {
     private final FileDataSourceBuilder delegate = new FileDataSourceBuilder();
@@ -274,10 +262,6 @@ public abstract class FileData {
 
   /**
    * Builder for creating an FDv2 {@link Synchronizer} that loads and watches file data.
-   * <p>
-   * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
-   * It is in early access. If you want access to this feature please join the EAP.
-   * <a href="https://launchdarkly.com/docs/sdk/features/data-saving-mode">https://launchdarkly.com/docs/sdk/features/data-saving-mode</a>
    */
   public static final class FileSynchronizerBuilder implements DataSourceBuilder<Synchronizer> {
     private final FileDataSourceBuilder delegate = new FileDataSourceBuilder();

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceBuildInputs.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceBuildInputs.java
@@ -10,9 +10,6 @@ import java.util.concurrent.ScheduledExecutorService;
 /**
  * Build information (dependencies and configuration) provided to initializer and synchronizer builders.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature, please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * <p>
  * This consolidates all the parameters needed to construct data source components,
  * including HTTP configuration, logging, scheduling, and selector state.
  */

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceBuilder.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceBuilder.java
@@ -3,9 +3,6 @@ package com.launchdarkly.sdk.server.subsystems;
 
 /**
  * Interface for building synchronizers and initializers.
- * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature, please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
  * @param <TDataSource>
  */
 public interface DataSourceBuilder<TDataSource> {

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceUpdateSinkV2.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSourceUpdateSinkV2.java
@@ -10,9 +10,6 @@ import com.launchdarkly.sdk.server.interfaces.DataStoreStatusProvider;
  * <p>
  * This interface extends {@link TransactionalDataSourceUpdateSink} to add status tracking
  * and status update capabilities required for FDv2 data sources.
- * <p>
- * This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
  * 
  * @since 5.0.0
  * @see TransactionalDataSourceUpdateSink

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSystemConfiguration.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/DataSystemConfiguration.java
@@ -7,10 +7,6 @@ import com.launchdarkly.sdk.server.datasources.Synchronizer;
 /**
  * Configuration for the SDK's data acquisition and storage strategy.
  * <p>
- * This class is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
- * </p>
- * <p>
  * Applications should use {@link com.launchdarkly.sdk.server.integrations.DataSystemBuilder} or
  * {@link com.launchdarkly.sdk.server.integrations.DataSystemModes} to create instances of this class,
  * rather than calling the constructor directly.

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/TransactionalDataSourceUpdateSink.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/TransactionalDataSourceUpdateSink.java
@@ -16,9 +16,6 @@ import java.util.Map;
  * <p>
  * Component factories for {@link DataSource} implementations will receive an implementation of this
  * interface in the {@link ClientContext#getDataSourceUpdateSink()} property of {@link ClientContext}.
- * <p>
- * This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
  * 
  * @since 5.0.0
  * @see DataSource

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/TransactionalDataStore.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/subsystems/TransactionalDataStore.java
@@ -18,9 +18,6 @@ import java.util.Map;
  * {@link PersistentDataStore}.
  * <p>
  * Implementations must be thread-safe.
- * <p>
- * This interface is not stable, and not subject to any backwards compatibility guarantees or semantic versioning.
- * It is in early access. If you want access to this feature please join the EAP. https://launchdarkly.com/docs/sdk/features/data-saving-mode
  * 
  * @see PersistentDataStore
  */


### PR DESCRIPTION
## Summary

- FDv2 / data-saving mode is going GA per the [SDK Release Standards spec](https://github.com/launchdarkly/sdk-specs/tree/main/specs/RELEASE-sdk-release-standards). GA-stage features must not carry experimental / pre-release warning prose in their public API surface.
- Removes the `<p>` warning paragraphs ("not stable, and not subject to any backwards compatibility guarantees", "in early access. Please join the EAP") from Javadoc on FDv2-related types in `lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/`. Descriptive Javadoc and `@param` / `@return` / `@see` tags are preserved.

Tracking: [SDK-2349](https://launchdarkly.atlassian.net/browse/SDK-2349)

## Test plan

- [x] `./gradlew compileJava` clean
- [ ] CI green

[SDK-2349]: https://launchdarkly.atlassian.net/browse/SDK-2349?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Documentation-only changes that remove early-access/compatibility warning paragraphs from FDv2-related Javadocs; no runtime logic or APIs are modified.
> 
> **Overview**
> Promotes FDv2/data-system APIs toward GA by removing the *early-access / no-compatibility-guarantees / EAP* warning paragraphs from Javadocs across `Components.dataSystem()`, `LDConfig.Builder#dataSystem`, and FDv2 data system types (builders, components, and subsystem interfaces).
> 
> All changes are comment/Javadoc edits only; signatures and behavior remain the same.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56fcb3deee0ac0b55ccc1462cabfb692a918e570. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->