### PR TITLE
test: fix flaky debugModeExpiresBasedOnServerTime test

### DIFF
--- a/lib/shared/internal/src/test/java/com/launchdarkly/sdk/internal/events/DefaultEventProcessorOutputTest.java
+++ b/lib/shared/internal/src/test/java/com/launchdarkly/sdk/internal/events/DefaultEventProcessorOutputTest.java
@@ -258,6 +258,7 @@ public class DefaultEventProcessorOutputTest extends BaseEventTest {
       ep.sendEvent(identifyEvent(LDContext.create("otherUser")));
       ep.flushBlocking(); // wait till flush is done so we know we received the first response, with the date
       es.awaitRequest();
+      ep.waitUntilInactive(); // ensure the flush worker has finished processing the response (setting lastKnownPastTime)
 
       es.receivedParams.clear();
       es.result = new EventSender.Result(true, false, null);
@@ -289,6 +290,7 @@ public class DefaultEventProcessorOutputTest extends BaseEventTest {
       ep.sendEvent(identifyEvent(LDContext.create("otherUser")));
       ep.flushBlocking(); // wait till flush is done so we know we received the first response, with the date
       es.awaitRequest();
+      ep.waitUntilInactive(); // ensure the flush worker has finished processing the response (setting lastKnownPastTime)
 
       es.receivedParams.clear();
       es.result = new EventSender.Result(true, false, null);


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Fixes a flaky test in `DefaultEventProcessorOutputTest`.

**Describe the solution you've provided**

Added `ep.waitUntilInactive()` calls after `es.awaitRequest()` in both `debugModeExpires*` tests. This ensures the flush worker has fully completed processing the HTTP response — including calling `handleResponse()` which sets `lastKnownPastTime` — before the test proceeds to send the next event.

**Root cause**

`flushBlocking()` only waits for the FLUSH message to be processed by the dispatcher thread, which puts the payload on the worker queue and returns. `awaitRequest()` returns as soon as `MockEventSender.receive()` adds to `receivedParams`, which happens before `SendEventsTask.run()` calls `responseListener.handleResponse(result)`. This means `lastKnownPastTime` may not be set when the test sends the second event, causing the debug mode expiration check to use only client time (which is 19s behind `debugUntil`), resulting in an unexpected debug event.

**Describe alternatives you've considered**

- Adding a `Thread.sleep()` after `awaitRequest()` — fragile and non-deterministic.
- Modifying the application code — not appropriate since this is a test synchronization issue.

**Additional context**

This test has been flaking at ~6% rate across the last 100 CI runs. All observed failures show the same pattern: a `debug` event appears where only a `summary` event was expected.


Link to Devin session: https://app.devin.ai/sessions/4b0d94a56a834efb9c0a758755e6653e
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only synchronization changes with no production or API impact.
> 
> **Overview**
> Adds **`ep.waitUntilInactive()`** after the initial flush and **`es.awaitRequest()`** in **`debugModeExpiresBasedOnClientTimeIfClientTimeIsLaterThanServerTime`** and **`debugModeExpiresBasedOnServerTimeIfServerTimeIsLaterThanClientTime`**.
> 
> The tests were racing: **`awaitRequest()`** could return before the flush worker ran **`handleResponse()`** and set **`lastKnownPastTime`**, so the second feature event sometimes still emitted a **debug** event instead of only a **summary**. Waiting until the processor is inactive ties the setup step to that response handling.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3e2086b592ebf8ab4dc0c91e84ce3ed92953d745. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->