### PR TITLE
test: poll for port release in TcpServerTest to fix flake

### DIFF
--- a/lib/shared/test-helpers/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpServerTest.java
+++ b/lib/shared/test-helpers/src/test/java/com/launchdarkly/testhelpers/tcptest/TcpServerTest.java
@@ -21,7 +21,7 @@ public class TcpServerTest {
       port = server.getPort();
       try (Socket s = new Socket("localhost", server.getPort())) {} // just verify that we can connect
     }
-    assertFalse("expected listener to be closed, but it wasn't", doesPortHaveListener(port));
+    assertPortReleased(port);
   }
 
   @Test
@@ -37,6 +37,21 @@ public class TcpServerTest {
       assertEquals(specificPort, server.getPort());
       try (Socket s = new Socket("localhost", specificPort)) {} // just verify that we can connect
     }
-    assertFalse("expected listener to be closed, but it wasn't", doesPortHaveListener(specificPort));
+    assertPortReleased(specificPort);
+  }
+
+  private static void assertPortReleased(int port) {
+    long deadline = System.currentTimeMillis() + 1000;
+    while (System.currentTimeMillis() < deadline) {
+      if (!doesPortHaveListener(port)) {
+        return;
+      }
+      try {
+        Thread.sleep(50);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+    assertFalse("expected listener to be closed, but it wasn't", doesPortHaveListener(port));
   }
 }


### PR DESCRIPTION
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's [pull request submission guidelines](../blob/main/CONTRIBUTING.md#submitting-pull-requests)
- [x] I have validated my changes against all supported platform versions

**Related issues**

Fixes a flaky `TcpServerTest.listensOnSpecificPort` test observed in CI.

**Describe the solution you've provided**

After `TcpServer.close()`, there can be a brief OS-level delay before the port is fully released. The test was immediately checking `doesPortHaveListener()` which could return true in that window.

Replaced the immediate `assertFalse` calls with a polling helper (`assertPortReleased`) that retries for up to 1 second before failing. Applied to both `listensOnSpecificPort` and `listensOnAnyAvailablePort` for consistency.

**Describe alternatives you've considered**

- Adding a fixed `Thread.sleep()` before the assertion — less robust and adds unnecessary delay in the common case.
- Modifying `TcpServer.close()` to join the accept thread — would be an application code change rather than a test fix.

**Additional context**

The flake was observed on `ubuntu-latest` with Java 19 during CI.

Link to Devin session: https://app.devin.ai/sessions/89320790abd2401e90b44eb0fcfb66be
Requested by: @kinyoklion

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Test-only timing change in shared test helpers; no production or security impact.
> 
> **Overview**
> **TcpServerTest** no longer asserts that a port is free the instant `TcpServer` closes. Both `listensOnAnyAvailablePort` and `listensOnSpecificPort` now call a new **`assertPortReleased`** helper that polls **`doesPortHaveListener`** for up to one second (50 ms between attempts) before failing with the same message as before.
> 
> This addresses CI flakes where the OS can still report a listener briefly after close.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 9d42e36880558905c331624883ed881742c8763c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->