### PR TITLE
feat: expose sslSocketFactory, sslParameters, and hostnameVerifier on RedisStoreBuilder

### DIFF
--- a/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreBuilder.java
+++ b/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreBuilder.java
@@ -11,6 +11,10 @@ import com.launchdarkly.sdk.server.subsystems.PersistentDataStore;
 import java.net.URI;
 import java.time.Duration;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
 
@@ -56,7 +60,7 @@ import redis.clients.jedis.Protocol;
  *         .build();
  * </code></pre>
  * 
- * @param <T> the component type that this builder is being used for 
+ * @param <T> the component type that this builder is being used for
  *
  * @since 5.0.0
  */
@@ -80,6 +84,9 @@ public abstract class RedisStoreBuilder<T> implements ComponentConfigurer<T>, Di
   String password = null;
   boolean tls = false;
   JedisPoolConfig poolConfig = null;
+  SSLSocketFactory sslSocketFactory = null;
+  SSLParameters sslParameters = null;
+  HostnameVerifier hostnameVerifier = null;
 
   // These constructors are called only from Implementations
   RedisStoreBuilder() {
@@ -146,7 +153,52 @@ public abstract class RedisStoreBuilder<T> implements ComponentConfigurer<T>, Di
     this.tls = tls;
     return this;
   }
-  
+
+  /**
+   * Optionally specifies a custom {@link SSLSocketFactory} for TLS connections.
+   * <p>
+   * This is only used when TLS is enabled (either via {@link #tls(boolean)} or by using a
+   * {@code rediss:} URI). If TLS is not enabled this value is silently ignored. If not set,
+   * the JVM default SSL socket factory is used.
+   *
+   * @param sslSocketFactory the SSL socket factory, or null to use the default
+   * @return the builder
+   */
+  public RedisStoreBuilder<T> sslSocketFactory(SSLSocketFactory sslSocketFactory) {
+    this.sslSocketFactory = sslSocketFactory;
+    return this;
+  }
+
+  /**
+   * Optionally specifies {@link SSLParameters} for TLS connections.
+   * <p>
+   * This is only used when TLS is enabled (either via {@link #tls(boolean)} or by using a
+   * {@code rediss:} URI). If TLS is not enabled this value is silently ignored. If not set,
+   * the JVM default SSL parameters are used.
+   *
+   * @param sslParameters the SSL parameters, or null to use the default
+   * @return the builder
+   */
+  public RedisStoreBuilder<T> sslParameters(SSLParameters sslParameters) {
+    this.sslParameters = sslParameters;
+    return this;
+  }
+
+  /**
+   * Optionally specifies a {@link HostnameVerifier} for TLS connections.
+   * <p>
+   * This is only used when TLS is enabled (either via {@link #tls(boolean)} or by using a
+   * {@code rediss:} URI). If TLS is not enabled this value is silently ignored. If not set,
+   * the JVM default hostname verifier is used.
+   *
+   * @param hostnameVerifier the hostname verifier, or null to use the default
+   * @return the builder
+   */
+  public RedisStoreBuilder<T> hostnameVerifier(HostnameVerifier hostnameVerifier) {
+    this.hostnameVerifier = hostnameVerifier;
+    return this;
+  }
+
   /**
    * Specifies a Redis host URI other than {@link #DEFAULT_URI}.
    * 

--- a/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
+++ b/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
@@ -40,6 +40,7 @@ abstract class RedisStoreImplBase implements Closeable {
     this.prefix = (builder.prefix == null || builder.prefix.isEmpty()) ?
         RedisStoreBuilder.DEFAULT_PREFIX :
         builder.prefix;
+
     this.pool = new JedisPool(poolConfig,
         host,
         port,
@@ -50,9 +51,9 @@ abstract class RedisStoreImplBase implements Closeable {
         database,
         null, // clientName
         tls,
-        null, // sslSocketFactory
-        null, // sslParameters
-        null  // hostnameVerifier
+        builder.sslSocketFactory,
+        builder.sslParameters,
+        builder.hostnameVerifier
     );
   }
 

--- a/lib/java-server-sdk-redis-store/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilderTest.java
+++ b/lib/java-server-sdk-redis-store/src/test/java/com/launchdarkly/sdk/server/integrations/RedisDataStoreBuilderTest.java
@@ -11,6 +11,11 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
+import javax.net.ssl.HostnameVerifier;
+import javax.net.ssl.HttpsURLConnection;
+import javax.net.ssl.SSLParameters;
+import javax.net.ssl.SSLSocketFactory;
+
 import redis.clients.jedis.JedisPoolConfig;
 import redis.clients.jedis.Protocol;
 
@@ -23,6 +28,9 @@ public class RedisDataStoreBuilderTest {
     assertNull(conf.database);
     assertNull(conf.password);
     assertFalse(conf.tls);
+    assertNull(conf.sslSocketFactory);
+    assertNull(conf.sslParameters);
+    assertNull(conf.hostnameVerifier);
     assertEquals(Duration.ofMillis(Protocol.DEFAULT_TIMEOUT), conf.connectTimeout);
     assertEquals(Duration.ofMillis(Protocol.DEFAULT_TIMEOUT), conf.socketTimeout);
     assertEquals(RedisStoreBuilder.DEFAULT_PREFIX, conf.prefix);
@@ -52,6 +60,27 @@ public class RedisDataStoreBuilderTest {
   public void testTlsConfigured() {
     RedisStoreBuilder<?> conf = Redis.dataStore().tls(true);
     assertTrue(conf.tls);
+  }
+
+  @Test
+  public void testSslSocketFactoryConfigured() {
+    SSLSocketFactory factory = (SSLSocketFactory) SSLSocketFactory.getDefault();
+    RedisStoreBuilder<?> conf = Redis.dataStore().sslSocketFactory(factory);
+    assertEquals(factory, conf.sslSocketFactory);
+  }
+
+  @Test
+  public void testSslParametersConfigured() {
+    SSLParameters params = new SSLParameters();
+    RedisStoreBuilder<?> conf = Redis.dataStore().sslParameters(params);
+    assertEquals(params, conf.sslParameters);
+  }
+
+  @Test
+  public void testHostnameVerifierConfigured() {
+    HostnameVerifier verifier = HttpsURLConnection.getDefaultHostnameVerifier();
+    RedisStoreBuilder<?> conf = Redis.dataStore().hostnameVerifier(verifier);
+    assertEquals(verifier, conf.hostnameVerifier);
   }
   
   @Test


### PR DESCRIPTION
**Expose SSL configuration options on RedisStoreBuilder**

The JedisPool constructor accepts sslSocketFactory, sslParameters, and hostnameVerifier for customizing TLS behaviour, but all three were hardcoded to null in RedisStoreImplBase, making them unreachable by callers.

This PR exposes all three as builder options on RedisStoreBuilder.

**Changes**

- Added sslSocketFactory(SSLSocketFactory), sslParameters(SSLParameters), and hostnameVerifier(HostnameVerifier) methods to RedisStoreBuilder
- Wired the new fields through to the JedisPool constructor in RedisStoreImplBase
- All three are no-ops when TLS is not enabled

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes affect how TLS Redis connections are established; misconfigured custom SSL or hostname verification could weaken security, though behavior is unchanged unless callers opt in.
> 
> **Overview**
> **RedisStoreBuilder** now lets callers pass **SSLSocketFactory**, **SSLParameters**, and **HostnameVerifier** for TLS Redis connections, matching what **JedisPool** already supports.
> 
> Previously **RedisStoreImplBase** always passed `null` for those three constructor arguments, so custom trust stores, cipher suites, or hostname checks were impossible without forking. The new builder fields are forwarded into **JedisPool**; when TLS is off they are documented as ignored, and unset values still defer to JVM defaults.
> 
> Unit tests cover default nulls and that each setter stores the configured instance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 86fa0cb72f13930e18ab1a8c0c53f71d1c2704c0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->