### PR TITLE
fix: Guard against null scheme in RedisStoreImplBase for relative URIs

### DIFF
--- a/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
+++ b/lib/java-server-sdk-redis-store/src/main/java/com/launchdarkly/sdk/server/integrations/RedisStoreImplBase.java
@@ -24,7 +24,7 @@ abstract class RedisStoreImplBase implements Closeable {
     String username = builder.username == null ? RedisURIComponents.getUsername(builder.uri) : builder.username;
     String password = builder.password == null ? RedisURIComponents.getPassword(builder.uri) : builder.password;
     int database = builder.database == null ? RedisURIComponents.getDBIndex(builder.uri) : builder.database;
-    boolean tls = builder.tls || builder.uri.getScheme().equals("rediss");
+    boolean tls = builder.tls || "rediss".equals(builder.uri.getScheme());
 
     String extra = tls ? " with TLS" : "";
     if (username != null) {


### PR DESCRIPTION
## Summary

`URI.getScheme()` returns `null` for scheme-less URIs such as `//localhost:6379`.
In `RedisStoreImplBase`, the TLS detection line:

```java
boolean tls = builder.tls || builder.uri.getScheme().equals("rediss");
```

called .equals() on that null, throwing an NPE at store construction time.

Fixed by flipping to the null-safe form:

boolean tls = builder.tls || "rediss".equals(builder.uri.getScheme());

A scheme-less URI now correctly resolves TLS to false (unless explicitly set via .tls(true)).

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single-line defensive null check with unchanged TLS semantics for valid `redis`/`rediss` URIs.
> 
> **Overview**
> **Fixes an NPE** when constructing the Redis data store from a URI with no scheme (e.g. `//localhost:6379`).
> 
> TLS detection in `RedisStoreImplBase` used `builder.uri.getScheme().equals("rediss")`, which throws if `getScheme()` is `null`. It now uses `"rediss".equals(builder.uri.getScheme())`, so scheme-less URIs are treated as non-TLS unless `builder.tls` is set explicitly.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 666069a1fd64127c7a42d092c33c547836b9bdbe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->