### PR TITLE
chore: include AISdkInfo in extra-files to keep version synced

### DIFF
--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
@@ -29,6 +29,7 @@ import com.launchdarkly.sdk.ObjectBuilder;
 import com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Mode;
 import com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Message;
 import com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Model;
+import com.launchdarkly.sdk.server.ai.internal.AISdkInfo;
 import com.launchdarkly.sdk.server.interfaces.LDClientInterface;
 
 import java.util.ArrayList;
@@ -70,9 +71,9 @@ public class LDAIClientImplTest {
   @Test
   public void constructorEmitsSdkInfoEvent() {
     LDValue expected = LDValue.buildObject()
-        .put("aiSdkName", "launchdarkly-java-server-sdk-ai")
-        .put("aiSdkVersion", "0.1.0")
-        .put("aiSdkLanguage", "java")
+        .put("aiSdkName", AISdkInfo.NAME)
+        .put("aiSdkVersion", AISdkInfo.VERSION)
+        .put("aiSdkLanguage", AISdkInfo.LANGUAGE)
         .build();
     verify(client).trackMetric(eq("$ld:ai:sdk:info"), any(LDContext.class), eq(expected), eq(1.0));
   }

--- a/release-please-config.json
+++ b/release-please-config.json
@@ -8,7 +8,8 @@
       "bump-minor-pre-major": true,
       "include-v-in-tag": false,
       "extra-files": [
-        "gradle.properties"
+        "gradle.properties",
+        "src/main/java/com/launchdarkly/sdk/server/ai/internal/AISdkInfo.java"
       ]
     },
     "lib/java-server-sdk-otel": {


### PR DESCRIPTION
## Summary

Adds `AISdkInfo.java` to Release Please `extra-files` so `AISdkInfo.VERSION` stays in sync with `gradle.properties` on each release PR. Follows the same pattern as the core Java server SDK and .NET AI SDK.

The SDK-info event test now references the `AISdkInfo` constants directly so future version bumps can't leave the expectation stale. No runtime behavior change.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Release automation and test expectations only; no production logic changes.
> 
> **Overview**
> **Release Please** for `lib/sdk/server-ai` now bumps `AISdkInfo.java` alongside `gradle.properties`, matching the core server SDK’s `Version.java` pattern so `AISdkInfo.VERSION` stays aligned on release PRs.
> 
> `constructorEmitsSdkInfoEvent` in `LDAIClientImplTest` asserts against `AISdkInfo.NAME`, `VERSION`, and `LANGUAGE` instead of hardcoded literals, so version bumps won’t leave the test out of date. **No runtime behavior change.**
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 07ff4bd0961ed83ed13282faa2fb2882b0426861. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->