### PR TITLE
feat(server-ai): stamp model metadata on AI usage events

### DIFF
--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAIClientImpl.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAIClientImpl.java
@@ -400,6 +400,8 @@ public final class LDAIClientImpl implements LDAIClient {
       String graphKey) {
     String modelName = model != null && model.getName() != null ? model.getName() : "";
     String providerName = provider != null && provider.getName() != null ? provider.getName() : "";
+    String modelKey = model != null ? model.getModelKey() : null;
+    int modelVersion = model != null ? model.getModelVersion() : 1;
     int ver = version != null ? version : 1;
     return () -> new LDAIConfigTrackerImpl(
         client,
@@ -409,6 +411,8 @@ public final class LDAIClientImpl implements LDAIClient {
         ver,
         modelName,
         providerName,
+        modelKey,
+        modelVersion,
         context,
         graphKey,
         logger);

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAIClientImpl.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/LDAIClientImpl.java
@@ -265,7 +265,8 @@ public final class LDAIClientImpl implements LDAIClient {
       String graphKey) {
     Supplier<LDAIConfigTracker> factory = trackerFactory(
         key, parsed.getVariationKey(), parsed.getVersion(),
-        parsed.getModel(), parsed.getProvider(), context, graphKey);
+        parsed.getModel(), parsed.getProvider(),
+        parsed.getModelKey(), parsed.getModelVersion(), context, graphKey);
     switch (mode) {
       case AGENT:
         return new AIAgentConfig(
@@ -330,7 +331,7 @@ public final class LDAIClientImpl implements LDAIClient {
       String graphKey) {
     // Default configs still get real trackers — the configKey was requested even if no flag was found.
     // variationKey is null because no flag evaluation occurred.
-    Supplier<LDAIConfigTracker> factory = trackerFactory(key, null, null, null, null, context, graphKey);
+    Supplier<LDAIConfigTracker> factory = trackerFactory(key, null, null, null, null, null, null, context, graphKey);
     switch (mode) {
       case AGENT: {
         AIAgentConfigDefault agent = (AIAgentConfigDefault) defaultValue;
@@ -386,23 +387,14 @@ public final class LDAIClientImpl implements LDAIClient {
       Integer version,
       com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Model model,
       com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Provider provider,
-      LDContext context) {
-    return trackerFactory(configKey, variationKey, version, model, provider, context, null);
-  }
-
-  private Supplier<LDAIConfigTracker> trackerFactory(
-      String configKey,
-      String variationKey,
-      Integer version,
-      com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Model model,
-      com.launchdarkly.sdk.server.ai.datamodel.LDAIConfigTypes.Provider provider,
+      String modelKey,
+      Integer modelVersion,
       LDContext context,
       String graphKey) {
     String modelName = model != null && model.getName() != null ? model.getName() : "";
     String providerName = provider != null && provider.getName() != null ? provider.getName() : "";
-    String modelKey = model != null ? model.getModelKey() : null;
-    int modelVersion = model != null ? model.getModelVersion() : 1;
     int ver = version != null ? version : 1;
+    int mVer = modelVersion != null ? modelVersion : 1;
     return () -> new LDAIConfigTrackerImpl(
         client,
         UUID.randomUUID().toString(),
@@ -412,7 +404,7 @@ public final class LDAIClientImpl implements LDAIClient {
         modelName,
         providerName,
         modelKey,
-        modelVersion,
+        mVer,
         context,
         graphKey,
         logger);

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAIConfigTypes.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAIConfigTypes.java
@@ -214,11 +214,20 @@ public final class LDAIConfigTypes {
    */
   public static final class Model {
     private final String name;
+    private final String modelKey;
+    private final int modelVersion;
     private final Map<String, Object> parameters;
     private final Map<String, Object> custom;
 
-    private Model(String name, Map<String, Object> parameters, Map<String, Object> custom) {
+    private Model(
+        String name,
+        String modelKey,
+        int modelVersion,
+        Map<String, Object> parameters,
+        Map<String, Object> custom) {
       this.name = name;
+      this.modelKey = modelKey;
+      this.modelVersion = modelVersion;
       this.parameters = parameters;
       this.custom = custom;
     }
@@ -230,6 +239,24 @@ public final class LDAIConfigTypes {
      */
     public String getName() {
       return name;
+    }
+
+    /**
+     * Returns the stable key of the model configuration.
+     *
+     * @return the model key, or {@code null} if none was specified
+     */
+    public String getModelKey() {
+      return modelKey;
+    }
+
+    /**
+     * Returns the version of the model configuration.
+     *
+     * @return the model version; defaults to {@code 1}
+     */
+    public int getModelVersion() {
+      return modelVersion;
     }
 
     /**
@@ -290,18 +317,21 @@ public final class LDAIConfigTypes {
       }
       Model other = (Model) o;
       return Objects.equals(name, other.name)
+          && Objects.equals(modelKey, other.modelKey)
+          && modelVersion == other.modelVersion
           && parameters.equals(other.parameters)
           && custom.equals(other.custom);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, parameters, custom);
+      return Objects.hash(name, modelKey, modelVersion, parameters, custom);
     }
 
     @Override
     public String toString() {
-      return "Model{name=" + name + ", parameters=" + parameters + ", custom=" + custom + '}';
+      return "Model{name=" + name + ", modelKey=" + modelKey + ", modelVersion=" + modelVersion
+          + ", parameters=" + parameters + ", custom=" + custom + '}';
     }
 
     /**
@@ -309,11 +339,35 @@ public final class LDAIConfigTypes {
      */
     public static final class Builder {
       private final String name;
+      private String modelKey;
+      private int modelVersion = 1;
       private Map<String, Object> parameters;
       private Map<String, Object> custom;
 
       private Builder(String name) {
         this.name = name;
+      }
+
+      /**
+       * Sets the stable key of the model configuration.
+       *
+       * @param modelKey the model key; may be {@code null}
+       * @return this builder
+       */
+      public Builder modelKey(String modelKey) {
+        this.modelKey = modelKey;
+        return this;
+      }
+
+      /**
+       * Sets the version of the model configuration.
+       *
+       * @param modelVersion the model version
+       * @return this builder
+       */
+      public Builder modelVersion(int modelVersion) {
+        this.modelVersion = modelVersion;
+        return this;
       }
 
       /**
@@ -350,7 +404,7 @@ public final class LDAIConfigTypes {
         Map<String, Object> cust = custom == null
             ? Collections.<String, Object>emptyMap()
             : Collections.unmodifiableMap(new HashMap<>(custom));
-        return new Model(name, params, cust);
+        return new Model(name, modelKey, modelVersion, params, cust);
       }
     }
   }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAIConfigTypes.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAIConfigTypes.java
@@ -214,20 +214,14 @@ public final class LDAIConfigTypes {
    */
   public static final class Model {
     private final String name;
-    private final String modelKey;
-    private final int modelVersion;
     private final Map<String, Object> parameters;
     private final Map<String, Object> custom;
 
     private Model(
         String name,
-        String modelKey,
-        int modelVersion,
         Map<String, Object> parameters,
         Map<String, Object> custom) {
       this.name = name;
-      this.modelKey = modelKey;
-      this.modelVersion = modelVersion;
       this.parameters = parameters;
       this.custom = custom;
     }
@@ -239,24 +233,6 @@ public final class LDAIConfigTypes {
      */
     public String getName() {
       return name;
-    }
-
-    /**
-     * Returns the stable key of the model configuration.
-     *
-     * @return the model key, or {@code null} if none was specified
-     */
-    public String getModelKey() {
-      return modelKey;
-    }
-
-    /**
-     * Returns the version of the model configuration.
-     *
-     * @return the model version; defaults to {@code 1}
-     */
-    public int getModelVersion() {
-      return modelVersion;
     }
 
     /**
@@ -317,21 +293,18 @@ public final class LDAIConfigTypes {
       }
       Model other = (Model) o;
       return Objects.equals(name, other.name)
-          && Objects.equals(modelKey, other.modelKey)
-          && modelVersion == other.modelVersion
           && parameters.equals(other.parameters)
           && custom.equals(other.custom);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(name, modelKey, modelVersion, parameters, custom);
+      return Objects.hash(name, parameters, custom);
     }
 
     @Override
     public String toString() {
-      return "Model{name=" + name + ", modelKey=" + modelKey + ", modelVersion=" + modelVersion
-          + ", parameters=" + parameters + ", custom=" + custom + '}';
+      return "Model{name=" + name + ", parameters=" + parameters + ", custom=" + custom + '}';
     }
 
     /**
@@ -339,35 +312,11 @@ public final class LDAIConfigTypes {
      */
     public static final class Builder {
       private final String name;
-      private String modelKey;
-      private int modelVersion = 1;
       private Map<String, Object> parameters;
       private Map<String, Object> custom;
 
       private Builder(String name) {
         this.name = name;
-      }
-
-      /**
-       * Sets the stable key of the model configuration.
-       *
-       * @param modelKey the model key; may be {@code null}
-       * @return this builder
-       */
-      public Builder modelKey(String modelKey) {
-        this.modelKey = modelKey;
-        return this;
-      }
-
-      /**
-       * Sets the version of the model configuration.
-       *
-       * @param modelVersion the model version
-       * @return this builder
-       */
-      public Builder modelVersion(int modelVersion) {
-        this.modelVersion = modelVersion;
-        return this;
       }
 
       /**
@@ -404,7 +353,7 @@ public final class LDAIConfigTypes {
         Map<String, Object> cust = custom == null
             ? Collections.<String, Object>emptyMap()
             : Collections.unmodifiableMap(new HashMap<>(custom));
-        return new Model(name, modelKey, modelVersion, params, cust);
+        return new Model(name, params, cust);
       }
     }
   }

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAITrackingTypes.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/datamodel/LDAITrackingTypes.java
@@ -599,6 +599,8 @@ public final class LDAITrackingTypes {
     private final int version;
     private final String modelName;
     private final String providerName;
+    private final String modelKey;
+    private final int modelVersion;
     private final String graphKey;
 
     /**
@@ -610,6 +612,8 @@ public final class LDAITrackingTypes {
      * @param version the config version
      * @param modelName the model name, or empty string when unknown
      * @param providerName the provider name, or empty string when unknown
+     * @param modelKey the stable model key, or {@code null} when unknown
+     * @param modelVersion the model version
      * @param graphKey the agent graph key, or {@code null} when not part of a graph
      */
     public TrackData(
@@ -619,6 +623,8 @@ public final class LDAITrackingTypes {
         int version,
         String modelName,
         String providerName,
+        String modelKey,
+        int modelVersion,
         String graphKey) {
       this.runId = Objects.requireNonNull(runId, "runId");
       this.configKey = Objects.requireNonNull(configKey, "configKey");
@@ -626,6 +632,8 @@ public final class LDAITrackingTypes {
       this.version = version;
       this.modelName = modelName == null ? "" : modelName;
       this.providerName = providerName == null ? "" : providerName;
+      this.modelKey = modelKey == null || modelKey.trim().isEmpty() ? null : modelKey;
+      this.modelVersion = modelVersion;
       this.graphKey = graphKey;
     }
 
@@ -684,6 +692,24 @@ public final class LDAITrackingTypes {
     }
 
     /**
+     * Returns the stable model key.
+     *
+     * @return the model key, or {@code null} when unknown
+     */
+    public String getModelKey() {
+      return modelKey;
+    }
+
+    /**
+     * Returns the model version.
+     *
+     * @return the model version
+     */
+    public int getModelVersion() {
+      return modelVersion;
+    }
+
+    /**
      * Returns the agent graph key.
      *
      * @return the graph key, or {@code null} when not part of a graph
@@ -695,7 +721,7 @@ public final class LDAITrackingTypes {
     /**
      * Builds an {@link LDValue} representation of this track data using camelCase keys.
      * <p>
-     * {@code variationKey} and {@code graphKey} are omitted when {@code null}.
+     * {@code variationKey}, {@code modelKey}, and {@code graphKey} are omitted when {@code null}.
      *
      * @return an {@link LDValue} object containing all non-null fields
      */
@@ -705,9 +731,13 @@ public final class LDAITrackingTypes {
           .put("configKey", configKey)
           .put("version", version)
           .put("modelName", modelName)
-          .put("providerName", providerName);
+          .put("providerName", providerName)
+          .put("modelVersion", modelVersion);
       if (variationKey != null) {
         b.put("variationKey", variationKey);
+      }
+      if (modelKey != null) {
+        b.put("modelKey", modelKey);
       }
       if (graphKey != null) {
         b.put("graphKey", graphKey);

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigFlagValue.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigFlagValue.java
@@ -37,6 +37,8 @@ public final class AIConfigFlagValue {
   private final Map<String, Tool> tools;
   private final JudgeConfiguration judgeConfiguration;
   private final String evaluationMetricKey;
+  private final String modelKey;
+  private final Integer modelVersion;
 
   private AIConfigFlagValue(Builder b) {
     this.enabled = b.enabled;
@@ -50,6 +52,8 @@ public final class AIConfigFlagValue {
     this.tools = b.tools == null ? null : Collections.unmodifiableMap(b.tools);
     this.judgeConfiguration = b.judgeConfiguration;
     this.evaluationMetricKey = b.evaluationMetricKey;
+    this.modelKey = b.modelKey;
+    this.modelVersion = b.modelVersion;
   }
 
   /**
@@ -95,6 +99,26 @@ public final class AIConfigFlagValue {
    */
   public Mode getMode() {
     return mode;
+  }
+
+  /**
+   * Returns the {@code _ldMeta.modelKey}. Lives under {@code _ldMeta} rather than {@code model}
+   * itself, to avoid {@code modelVersion} reading as the underlying LLM's own version
+   * (e.g. "GPT-5.4").
+   *
+   * @return the model key, or {@code null} if absent
+   */
+  public String getModelKey() {
+    return modelKey;
+  }
+
+  /**
+   * Returns the {@code _ldMeta.modelVersion}.
+   *
+   * @return the model version, or {@code null} if absent
+   */
+  public Integer getModelVersion() {
+    return modelVersion;
   }
 
   /**
@@ -184,6 +208,8 @@ public final class AIConfigFlagValue {
     private Map<String, Tool> tools;
     private JudgeConfiguration judgeConfiguration;
     private String evaluationMetricKey;
+    private String modelKey;
+    private Integer modelVersion;
 
     private Builder() {
     }
@@ -219,6 +245,48 @@ public final class AIConfigFlagValue {
     public Builder version(Integer v) {
       this.version = v;
       return this;
+    }
+
+    /**
+     * Sets the model key, parsed from {@code _ldMeta.modelKey}.
+     *
+     * @param v the model key
+     * @return this builder
+     */
+    public Builder modelKey(String v) {
+      this.modelKey = v;
+      return this;
+    }
+
+    /**
+     * Sets the model version, parsed from {@code _ldMeta.modelVersion}.
+     *
+     * @param v the model version
+     * @return this builder
+     */
+    public Builder modelVersion(Integer v) {
+      this.modelVersion = v;
+      return this;
+    }
+
+    /**
+     * Returns the model key set so far, for {@link AIConfigParser} to pass into
+     * {@link AIConfigParser#parseModel} alongside the {@code model} value.
+     *
+     * @return the model key, or {@code null} if unset
+     */
+    String getModelKey() {
+      return modelKey;
+    }
+
+    /**
+     * Returns the model version set so far, for {@link AIConfigParser} to pass into
+     * {@link AIConfigParser#parseModel} alongside the {@code model} value.
+     *
+     * @return the model version, or {@code null} if unset
+     */
+    Integer getModelVersion() {
+      return modelVersion;
     }
 
     /**

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigFlagValue.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigFlagValue.java
@@ -270,26 +270,6 @@ public final class AIConfigFlagValue {
     }
 
     /**
-     * Returns the model key set so far, for {@link AIConfigParser} to pass into
-     * {@link AIConfigParser#parseModel} alongside the {@code model} value.
-     *
-     * @return the model key, or {@code null} if unset
-     */
-    String getModelKey() {
-      return modelKey;
-    }
-
-    /**
-     * Returns the model version set so far, for {@link AIConfigParser} to pass into
-     * {@link AIConfigParser#parseModel} alongside the {@code model} value.
-     *
-     * @return the model version, or {@code null} if unset
-     */
-    Integer getModelVersion() {
-      return modelVersion;
-    }
-
-    /**
      * Sets the mode.
      *
      * @param v the mode

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -42,8 +42,9 @@ public final class AIConfigParser {
       return builder.build();
     }
 
-    parseMeta(value.get("_ldMeta"), builder);
-    builder.model(parseModel(value.get("model")));
+    LDValue meta = value.get("_ldMeta");
+    parseMeta(meta, builder);
+    builder.model(parseModel(value.get("model"), meta));
     builder.provider(parseProvider(value.get("provider")));
     builder.messages(parseMessages(value.get("messages")));
     builder.instructions(asStringOrNull(value.get("instructions")));
@@ -71,19 +72,24 @@ public final class AIConfigParser {
   }
 
   /**
-   * Parses a {@code model} object.
+   * Parses a {@code model} object. {@code modelKey}/{@code modelVersion} live under
+   * {@code _ldMeta} rather than {@code model} itself, to avoid reading as the underlying LLM's
+   * own version (e.g. "GPT-5.4").
    *
    * @param model the model value
+   * @param meta the {@code _ldMeta} value, for modelKey/modelVersion
    * @return a {@link Model}, or {@code null} if the value is not an object
    */
-  static Model parseModel(LDValue model) {
+  static Model parseModel(LDValue model, LDValue meta) {
     if (model == null || model.getType() != LDValueType.OBJECT) {
       return null;
     }
-    LDValue modelVersion = model.get("modelVersion");
+    boolean hasMeta = meta != null && meta.getType() == LDValueType.OBJECT;
+    LDValue modelVersion = hasMeta ? meta.get("modelVersion") : LDValue.ofNull();
     int version = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
+    String modelKey = hasMeta ? asStringOrNull(meta.get("modelKey")) : null;
     return Model.builder(asStringOrNull(model.get("name")))
-        .modelKey(trimToNull(asStringOrNull(model.get("modelKey"))))
+        .modelKey(trimToNull(modelKey))
         .modelVersion(version)
         .parameters(LDValueConverter.toMap(model.get("parameters")))
         .custom(LDValueConverter.toMap(model.get("custom")))

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -83,7 +83,7 @@ public final class AIConfigParser {
     LDValue modelVersion = model.get("modelVersion");
     int version = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
     return Model.builder(asStringOrNull(model.get("name")))
-        .modelKey(asStringOrNull(model.get("modelKey")))
+        .modelKey(trimToNull(asStringOrNull(model.get("modelKey"))))
         .modelVersion(version)
         .parameters(LDValueConverter.toMap(model.get("parameters")))
         .custom(LDValueConverter.toMap(model.get("custom")))

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -43,8 +43,9 @@ public final class AIConfigParser {
     }
 
     LDValue meta = value.get("_ldMeta");
-    ModelIdentity modelIdentity = parseMeta(meta, builder);
-    builder.model(parseModel(value.get("model"), modelIdentity.modelKey, modelIdentity.modelVersion));
+    parseMeta(meta, builder);
+    Integer modelVersion = builder.getModelVersion();
+    builder.model(parseModel(value.get("model"), builder.getModelKey(), modelVersion == null ? 1 : modelVersion));
     builder.provider(parseProvider(value.get("provider")));
     builder.messages(parseMessages(value.get("messages")));
     builder.instructions(asStringOrNull(value.get("instructions")));
@@ -55,25 +56,14 @@ public final class AIConfigParser {
     return builder.build();
   }
 
-  /**
-   * Holds {@code modelKey}/{@code modelVersion} as parsed from {@code _ldMeta} by
-   * {@link #parseMeta}, for {@link #parseModel} to attach to the {@link Model} it builds.
-   * These fields live under {@code _ldMeta} rather than {@code model} itself, to avoid
-   * {@code modelVersion} reading as the underlying LLM's own version (e.g. "GPT-5.4").
-   */
-  private static final class ModelIdentity {
-    final String modelKey;
-    final int modelVersion;
-
-    ModelIdentity(String modelKey, int modelVersion) {
-      this.modelKey = modelKey;
-      this.modelVersion = modelVersion;
-    }
-  }
-
-  private static ModelIdentity parseMeta(LDValue meta, AIConfigFlagValue.Builder builder) {
+  // modelKey/modelVersion are parsed here alongside the rest of _ldMeta (enabled, variationKey,
+  // version, mode) rather than inside parseModel, so they're stored the same way as every other
+  // _ldMeta field instead of a one-off path. They also live under _ldMeta rather than model
+  // itself, to avoid modelVersion reading as the underlying LLM's own version (e.g. "GPT-5.4").
+  private static void parseMeta(LDValue meta, AIConfigFlagValue.Builder builder) {
     if (meta == null || meta.getType() != LDValueType.OBJECT) {
-      return new ModelIdentity(null, 1);
+      builder.modelVersion(1);
+      return;
     }
     LDValue enabled = meta.get("enabled");
     if (enabled.getType() == LDValueType.BOOLEAN) {
@@ -87,9 +77,8 @@ public final class AIConfigParser {
     builder.mode(Mode.fromWireValue(asStringOrNull(meta.get("mode"))));
 
     LDValue modelVersion = meta.get("modelVersion");
-    int parsedModelVersion = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
-    String modelKey = trimToNull(asStringOrNull(meta.get("modelKey")));
-    return new ModelIdentity(modelKey, parsedModelVersion);
+    builder.modelVersion(modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1);
+    builder.modelKey(trimToNull(asStringOrNull(meta.get("modelKey"))));
   }
 
   /**

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -80,7 +80,11 @@ public final class AIConfigParser {
     if (model == null || model.getType() != LDValueType.OBJECT) {
       return null;
     }
+    LDValue modelVersion = model.get("modelVersion");
+    int version = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
     return Model.builder(asStringOrNull(model.get("name")))
+        .modelKey(asStringOrNull(model.get("modelKey")))
+        .modelVersion(version)
         .parameters(LDValueConverter.toMap(model.get("parameters")))
         .custom(LDValueConverter.toMap(model.get("custom")))
         .build();

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -43,8 +43,8 @@ public final class AIConfigParser {
     }
 
     LDValue meta = value.get("_ldMeta");
-    parseMeta(meta, builder);
-    builder.model(parseModel(value.get("model"), meta));
+    ModelIdentity modelIdentity = parseMeta(meta, builder);
+    builder.model(parseModel(value.get("model"), modelIdentity.modelKey, modelIdentity.modelVersion));
     builder.provider(parseProvider(value.get("provider")));
     builder.messages(parseMessages(value.get("messages")));
     builder.instructions(asStringOrNull(value.get("instructions")));
@@ -55,9 +55,25 @@ public final class AIConfigParser {
     return builder.build();
   }
 
-  private static void parseMeta(LDValue meta, AIConfigFlagValue.Builder builder) {
+  /**
+   * Holds {@code modelKey}/{@code modelVersion} as parsed from {@code _ldMeta} by
+   * {@link #parseMeta}, for {@link #parseModel} to attach to the {@link Model} it builds.
+   * These fields live under {@code _ldMeta} rather than {@code model} itself, to avoid
+   * {@code modelVersion} reading as the underlying LLM's own version (e.g. "GPT-5.4").
+   */
+  private static final class ModelIdentity {
+    final String modelKey;
+    final int modelVersion;
+
+    ModelIdentity(String modelKey, int modelVersion) {
+      this.modelKey = modelKey;
+      this.modelVersion = modelVersion;
+    }
+  }
+
+  private static ModelIdentity parseMeta(LDValue meta, AIConfigFlagValue.Builder builder) {
     if (meta == null || meta.getType() != LDValueType.OBJECT) {
-      return;
+      return new ModelIdentity(null, 1);
     }
     LDValue enabled = meta.get("enabled");
     if (enabled.getType() == LDValueType.BOOLEAN) {
@@ -69,28 +85,29 @@ public final class AIConfigParser {
       builder.version(version.intValue());
     }
     builder.mode(Mode.fromWireValue(asStringOrNull(meta.get("mode"))));
+
+    LDValue modelVersion = meta.get("modelVersion");
+    int parsedModelVersion = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
+    String modelKey = trimToNull(asStringOrNull(meta.get("modelKey")));
+    return new ModelIdentity(modelKey, parsedModelVersion);
   }
 
   /**
-   * Parses a {@code model} object. {@code modelKey}/{@code modelVersion} live under
-   * {@code _ldMeta} rather than {@code model} itself, to avoid reading as the underlying LLM's
-   * own version (e.g. "GPT-5.4").
+   * Parses a {@code model} object, attaching the {@code modelKey}/{@code modelVersion} already
+   * parsed from {@code _ldMeta} by {@link #parseMeta}.
    *
    * @param model the model value
-   * @param meta the {@code _ldMeta} value, for modelKey/modelVersion
+   * @param modelKey the model key parsed from {@code _ldMeta}, or {@code null}
+   * @param modelVersion the model version parsed from {@code _ldMeta}, defaulting to 1
    * @return a {@link Model}, or {@code null} if the value is not an object
    */
-  static Model parseModel(LDValue model, LDValue meta) {
+  static Model parseModel(LDValue model, String modelKey, int modelVersion) {
     if (model == null || model.getType() != LDValueType.OBJECT) {
       return null;
     }
-    boolean hasMeta = meta != null && meta.getType() == LDValueType.OBJECT;
-    LDValue modelVersion = hasMeta ? meta.get("modelVersion") : LDValue.ofNull();
-    int version = modelVersion.getType() == LDValueType.NUMBER ? modelVersion.intValue() : 1;
-    String modelKey = hasMeta ? asStringOrNull(meta.get("modelKey")) : null;
     return Model.builder(asStringOrNull(model.get("name")))
-        .modelKey(trimToNull(modelKey))
-        .modelVersion(version)
+        .modelKey(modelKey)
+        .modelVersion(modelVersion)
         .parameters(LDValueConverter.toMap(model.get("parameters")))
         .custom(LDValueConverter.toMap(model.get("custom")))
         .build();

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParser.java
@@ -44,8 +44,7 @@ public final class AIConfigParser {
 
     LDValue meta = value.get("_ldMeta");
     parseMeta(meta, builder);
-    Integer modelVersion = builder.getModelVersion();
-    builder.model(parseModel(value.get("model"), builder.getModelKey(), modelVersion == null ? 1 : modelVersion));
+    builder.model(parseModel(value.get("model")));
     builder.provider(parseProvider(value.get("provider")));
     builder.messages(parseMessages(value.get("messages")));
     builder.instructions(asStringOrNull(value.get("instructions")));
@@ -82,21 +81,16 @@ public final class AIConfigParser {
   }
 
   /**
-   * Parses a {@code model} object, attaching the {@code modelKey}/{@code modelVersion} already
-   * parsed from {@code _ldMeta} by {@link #parseMeta}.
+   * Parses a {@code model} object.
    *
    * @param model the model value
-   * @param modelKey the model key parsed from {@code _ldMeta}, or {@code null}
-   * @param modelVersion the model version parsed from {@code _ldMeta}, defaulting to 1
    * @return a {@link Model}, or {@code null} if the value is not an object
    */
-  static Model parseModel(LDValue model, String modelKey, int modelVersion) {
+  static Model parseModel(LDValue model) {
     if (model == null || model.getType() != LDValueType.OBJECT) {
       return null;
     }
     return Model.builder(asStringOrNull(model.get("name")))
-        .modelKey(modelKey)
-        .modelVersion(modelVersion)
         .parameters(LDValueConverter.toMap(model.get("parameters")))
         .custom(LDValueConverter.toMap(model.get("custom")))
         .build();

--- a/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImpl.java
+++ b/lib/sdk/server-ai/src/main/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImpl.java
@@ -58,6 +58,8 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
   private final int version;
   private final String modelName;   // empty string when unknown
   private final String providerName; // empty string when unknown
+  private final String modelKey;    // nullable
+  private final int modelVersion;
   private final String graphKey;    // nullable
 
   // Computed once at construction
@@ -86,6 +88,8 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
    * @param version the config version
    * @param modelName the model name, or empty string when unknown
    * @param providerName the provider name, or empty string when unknown
+   * @param modelKey the stable model key, or {@code null} when unknown
+   * @param modelVersion the model version
    * @param context the evaluation context; must not be {@code null}
    * @param graphKey the agent graph key, or {@code null} when not part of a graph
    * @param logger the logger; must not be {@code null}
@@ -98,6 +102,8 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
       int version,
       String modelName,
       String providerName,
+      String modelKey,
+      int modelVersion,
       LDContext context,
       String graphKey,
       LDLogger logger) {
@@ -108,6 +114,8 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
     this.version = version;
     this.modelName = modelName == null ? "" : modelName;
     this.providerName = providerName == null ? "" : providerName;
+    this.modelKey = modelKey == null || modelKey.trim().isEmpty() ? null : modelKey;
+    this.modelVersion = modelVersion;
     this.context = Objects.requireNonNull(context, "context");
     this.graphKey = graphKey;
     this.logger = Objects.requireNonNull(logger, "logger");
@@ -137,6 +145,8 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
         d.getVersion(),
         "", // modelName not carried in token
         "", // providerName not carried in token
+        null, // modelKey not carried in token
+        1, // modelVersion not carried in token
         context,
         d.getGraphKey(),
         logger);
@@ -144,7 +154,16 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
 
   @Override
   public TrackData getTrackData() {
-    return new TrackData(runId, configKey, variationKey, version, modelName, providerName, graphKey);
+    return new TrackData(
+        runId,
+        configKey,
+        variationKey,
+        version,
+        modelName,
+        providerName,
+        modelKey,
+        modelVersion,
+        graphKey);
   }
 
   @Override
@@ -377,9 +396,13 @@ public final class LDAIConfigTrackerImpl implements LDAIConfigTracker {
         .put("configKey", configKey)
         .put("version", version)
         .put("modelName", modelName)
-        .put("providerName", providerName);
+        .put("providerName", providerName)
+        .put("modelVersion", modelVersion);
     if (variationKey != null) {
       b.put("variationKey", variationKey);
+    }
+    if (modelKey != null) {
+      b.put("modelKey", modelKey);
     }
     if (graphKey != null) {
       b.put("graphKey", graphKey);

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
@@ -143,8 +143,8 @@ public class LDAIClientImplTest {
 
     AICompletionConfig config = ai.completionConfig("key", context, null, null);
 
-    assertThat(config.getModel().getModelKey(), is("custom-gpt"));
-    assertThat(config.getModel().getModelVersion(), is(7));
+    // modelKey/modelVersion are intentionally not exposed on Model; they surface only via the
+    // tracker's stamped event data, mirroring variationKey/version.
     assertThat(config.createTracker().getTrackData().getModelKey(), is("custom-gpt"));
     assertThat(config.createTracker().getTrackData().getModelVersion(), is(7));
   }
@@ -157,8 +157,6 @@ public class LDAIClientImplTest {
 
     AICompletionConfig config = ai.completionConfig("key", context, null, null);
 
-    assertThat(config.getModel().getModelKey(), is(nullValue()));
-    assertThat(config.getModel().getModelVersion(), is(1));
     assertThat(config.createTracker().getTrackData().getModelKey(), is(nullValue()));
     assertThat(config.createTracker().getTrackData().getModelVersion(), is(1));
   }

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
@@ -136,8 +136,9 @@ public class LDAIClientImplTest {
 
   @Test
   public void completionConfigPropagatesModelMetadataToTracker() {
-    String json = "{\"_ldMeta\":{\"enabled\":true,\"mode\":\"completion\"},"
-        + "\"model\":{\"name\":\"gpt-4\",\"modelKey\":\"custom-gpt\",\"modelVersion\":7}}";
+    String json = "{\"_ldMeta\":{\"enabled\":true,\"mode\":\"completion\","
+        + "\"modelKey\":\"custom-gpt\",\"modelVersion\":7},"
+        + "\"model\":{\"name\":\"gpt-4\"}}";
     when(client.jsonValueVariation(anyString(), any(), any())).thenReturn(LDValue.parse(json));
 
     AICompletionConfig config = ai.completionConfig("key", context, null, null);

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/LDAIClientImplTest.java
@@ -135,6 +135,34 @@ public class LDAIClientImplTest {
   }
 
   @Test
+  public void completionConfigPropagatesModelMetadataToTracker() {
+    String json = "{\"_ldMeta\":{\"enabled\":true,\"mode\":\"completion\"},"
+        + "\"model\":{\"name\":\"gpt-4\",\"modelKey\":\"custom-gpt\",\"modelVersion\":7}}";
+    when(client.jsonValueVariation(anyString(), any(), any())).thenReturn(LDValue.parse(json));
+
+    AICompletionConfig config = ai.completionConfig("key", context, null, null);
+
+    assertThat(config.getModel().getModelKey(), is("custom-gpt"));
+    assertThat(config.getModel().getModelVersion(), is(7));
+    assertThat(config.createTracker().getTrackData().getModelKey(), is("custom-gpt"));
+    assertThat(config.createTracker().getTrackData().getModelVersion(), is(7));
+  }
+
+  @Test
+  public void completionConfigDefaultsMissingModelMetadata() {
+    String json = "{\"_ldMeta\":{\"enabled\":true,\"mode\":\"completion\"},"
+        + "\"model\":{\"name\":\"gpt-4\"}}";
+    when(client.jsonValueVariation(anyString(), any(), any())).thenReturn(LDValue.parse(json));
+
+    AICompletionConfig config = ai.completionConfig("key", context, null, null);
+
+    assertThat(config.getModel().getModelKey(), is(nullValue()));
+    assertThat(config.getModel().getModelVersion(), is(1));
+    assertThat(config.createTracker().getTrackData().getModelKey(), is(nullValue()));
+    assertThat(config.createTracker().getTrackData().getModelVersion(), is(1));
+  }
+
+  @Test
   public void interpolationExposesContextAsLdctx() {
     String json = "{\"_ldMeta\":{\"enabled\":true,\"mode\":\"completion\"},"
         + "\"messages\":[{\"role\":\"user\",\"content\":\"{{ldctx.key}}\"}]}";

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
@@ -22,7 +22,8 @@ public class AIConfigParserTest {
   public void parsesFullCompletionConfig() {
     LDValue value = LDValue.parse("{"
         + "\"_ldMeta\":{\"variationKey\":\"v1\",\"enabled\":true,\"version\":3,\"mode\":\"completion\"},"
-        + "\"model\":{\"name\":\"gpt-4\",\"parameters\":{\"temperature\":0.7,\"maxTokens\":100},"
+        + "\"model\":{\"name\":\"gpt-4\",\"modelKey\":\"custom-gpt\",\"modelVersion\":7,"
+        + "\"parameters\":{\"temperature\":0.7,\"maxTokens\":100},"
         + "\"custom\":{\"team\":\"core\"}},"
         + "\"provider\":{\"name\":\"openai\"},"
         + "\"messages\":[{\"role\":\"system\",\"content\":\"You are {{persona}}.\"},"
@@ -39,6 +40,8 @@ public class AIConfigParserTest {
     assertThat(parsed.getVersion(), is(3));
     assertThat(parsed.getMode(), is(Mode.COMPLETION));
     assertThat(parsed.getModel().getName(), is("gpt-4"));
+    assertThat(parsed.getModel().getModelKey(), is("custom-gpt"));
+    assertThat(parsed.getModel().getModelVersion(), is(7));
     assertThat(parsed.getModel().getParameter("temperature"), is((Object) 0.7));
     assertThat(parsed.getModel().getParameter("maxTokens"), is((Object) 100L));
     assertThat(parsed.getModel().getCustom("team"), is((Object) "core"));
@@ -51,6 +54,19 @@ public class AIConfigParserTest {
     assertThat(judges.getJudges().get(0).getSamplingRate(), is(0.5));
     assertThat(parsed.getTools().keySet(), contains("search"));
     assertThat(parsed.getTools().get("search").getType(), is("function"));
+  }
+
+  @Test
+  public void modelMetadataDefaultsWhenMissingOrWrongType() {
+    AIConfigFlagValue missing = AIConfigParser.parse(
+        LDValue.parse("{\"model\":{\"name\":\"gpt-4\"}}"));
+    assertThat(missing.getModel().getModelKey(), is(nullValue()));
+    assertThat(missing.getModel().getModelVersion(), is(1));
+
+    AIConfigFlagValue wrongType = AIConfigParser.parse(
+        LDValue.parse("{\"model\":{\"modelKey\":3,\"modelVersion\":\"two\"}}"));
+    assertThat(wrongType.getModel().getModelKey(), is(nullValue()));
+    assertThat(wrongType.getModel().getModelVersion(), is(1));
   }
 
   @Test

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
@@ -67,6 +67,10 @@ public class AIConfigParserTest {
         LDValue.parse("{\"model\":{\"modelKey\":3,\"modelVersion\":\"two\"}}"));
     assertThat(wrongType.getModel().getModelKey(), is(nullValue()));
     assertThat(wrongType.getModel().getModelVersion(), is(1));
+
+    AIConfigFlagValue blankKey = AIConfigParser.parse(
+        LDValue.parse("{\"model\":{\"modelKey\":\"   \"}}"));
+    assertThat(blankKey.getModel().getModelKey(), is(nullValue()));
   }
 
   @Test

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
@@ -41,8 +41,8 @@ public class AIConfigParserTest {
     assertThat(parsed.getVersion(), is(3));
     assertThat(parsed.getMode(), is(Mode.COMPLETION));
     assertThat(parsed.getModel().getName(), is("gpt-4"));
-    assertThat(parsed.getModel().getModelKey(), is("custom-gpt"));
-    assertThat(parsed.getModel().getModelVersion(), is(7));
+    assertThat(parsed.getModelKey(), is("custom-gpt"));
+    assertThat(parsed.getModelVersion(), is(7));
     assertThat(parsed.getModel().getParameter("temperature"), is((Object) 0.7));
     assertThat(parsed.getModel().getParameter("maxTokens"), is((Object) 100L));
     assertThat(parsed.getModel().getCustom("team"), is((Object) "core"));
@@ -61,17 +61,17 @@ public class AIConfigParserTest {
   public void modelMetadataDefaultsWhenMissingOrWrongType() {
     AIConfigFlagValue missing = AIConfigParser.parse(
         LDValue.parse("{\"model\":{\"name\":\"gpt-4\"}}"));
-    assertThat(missing.getModel().getModelKey(), is(nullValue()));
-    assertThat(missing.getModel().getModelVersion(), is(1));
+    assertThat(missing.getModelKey(), is(nullValue()));
+    assertThat(missing.getModelVersion(), is(1));
 
     AIConfigFlagValue wrongType = AIConfigParser.parse(
         LDValue.parse("{\"_ldMeta\":{\"modelKey\":3,\"modelVersion\":\"two\"},\"model\":{}}"));
-    assertThat(wrongType.getModel().getModelKey(), is(nullValue()));
-    assertThat(wrongType.getModel().getModelVersion(), is(1));
+    assertThat(wrongType.getModelKey(), is(nullValue()));
+    assertThat(wrongType.getModelVersion(), is(1));
 
     AIConfigFlagValue blankKey = AIConfigParser.parse(
         LDValue.parse("{\"_ldMeta\":{\"modelKey\":\"   \"},\"model\":{}}"));
-    assertThat(blankKey.getModel().getModelKey(), is(nullValue()));
+    assertThat(blankKey.getModelKey(), is(nullValue()));
   }
 
   @Test

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/AIConfigParserTest.java
@@ -21,8 +21,9 @@ public class AIConfigParserTest {
   @Test
   public void parsesFullCompletionConfig() {
     LDValue value = LDValue.parse("{"
-        + "\"_ldMeta\":{\"variationKey\":\"v1\",\"enabled\":true,\"version\":3,\"mode\":\"completion\"},"
-        + "\"model\":{\"name\":\"gpt-4\",\"modelKey\":\"custom-gpt\",\"modelVersion\":7,"
+        + "\"_ldMeta\":{\"variationKey\":\"v1\",\"enabled\":true,\"version\":3,\"mode\":\"completion\","
+        + "\"modelKey\":\"custom-gpt\",\"modelVersion\":7},"
+        + "\"model\":{\"name\":\"gpt-4\","
         + "\"parameters\":{\"temperature\":0.7,\"maxTokens\":100},"
         + "\"custom\":{\"team\":\"core\"}},"
         + "\"provider\":{\"name\":\"openai\"},"
@@ -64,12 +65,12 @@ public class AIConfigParserTest {
     assertThat(missing.getModel().getModelVersion(), is(1));
 
     AIConfigFlagValue wrongType = AIConfigParser.parse(
-        LDValue.parse("{\"model\":{\"modelKey\":3,\"modelVersion\":\"two\"}}"));
+        LDValue.parse("{\"_ldMeta\":{\"modelKey\":3,\"modelVersion\":\"two\"},\"model\":{}}"));
     assertThat(wrongType.getModel().getModelKey(), is(nullValue()));
     assertThat(wrongType.getModel().getModelVersion(), is(1));
 
     AIConfigFlagValue blankKey = AIConfigParser.parse(
-        LDValue.parse("{\"model\":{\"modelKey\":\"   \"}}"));
+        LDValue.parse("{\"_ldMeta\":{\"modelKey\":\"   \"},\"model\":{}}"));
     assertThat(blankKey.getModel().getModelKey(), is(nullValue()));
   }
 

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
@@ -61,6 +61,8 @@ public class LDAIConfigTrackerImplTest {
   private static final int VERSION = 3;
   private static final String MODEL_NAME = "gpt-4";
   private static final String PROVIDER_NAME = "openai";
+  private static final String MODEL_KEY = "custom-gpt";
+  private static final int MODEL_VERSION = 7;
 
   @Before
   public void setUp() {
@@ -71,9 +73,14 @@ public class LDAIConfigTrackerImplTest {
   }
 
   private LDAIConfigTrackerImpl makeTracker(String variationKey) {
+    return makeTracker(variationKey, MODEL_KEY, MODEL_VERSION);
+  }
+
+  private LDAIConfigTrackerImpl makeTracker(
+      String variationKey, String modelKey, int modelVersion) {
     return new LDAIConfigTrackerImpl(
         client, RUN_ID, CONFIG_KEY, variationKey, VERSION,
-        MODEL_NAME, PROVIDER_NAME, CONTEXT, null, logger);
+        MODEL_NAME, PROVIDER_NAME, modelKey, modelVersion, CONTEXT, null, logger);
   }
 
   private List<String> warnings() {
@@ -98,6 +105,8 @@ public class LDAIConfigTrackerImplTest {
         .put("version", VERSION)
         .put("modelName", MODEL_NAME)
         .put("providerName", PROVIDER_NAME)
+        .put("modelKey", MODEL_KEY)
+        .put("modelVersion", MODEL_VERSION)
         .build();
   }
 
@@ -112,6 +121,8 @@ public class LDAIConfigTrackerImplTest {
     assertThat(data.getVersion(), is(VERSION));
     assertThat(data.getModelName(), is(MODEL_NAME));
     assertThat(data.getProviderName(), is(PROVIDER_NAME));
+    assertThat(data.getModelKey(), is(MODEL_KEY));
+    assertThat(data.getModelVersion(), is(MODEL_VERSION));
     assertThat(data.getGraphKey(), is(nullValue()));
   }
 
@@ -140,6 +151,12 @@ public class LDAIConfigTrackerImplTest {
   }
 
   @Test
+  public void resumptionTokenExcludesModelMetadata() {
+    LDAIConfigTrackerImpl other = makeTracker(VARIATION_KEY, "different-model", 99);
+    assertThat(other.getResumptionToken(), is(tracker.getResumptionToken()));
+  }
+
+  @Test
   public void fromResumptionTokenRestoresCorrectFields() {
     String token = tracker.getResumptionToken();
     LDAIConfigTrackerImpl restored =
@@ -151,6 +168,8 @@ public class LDAIConfigTrackerImplTest {
     assertThat(data.getVersion(), is(VERSION));
     assertThat(data.getModelName(), is("")); // not in token
     assertThat(data.getProviderName(), is("")); // not in token
+    assertThat(data.getModelKey(), is(nullValue())); // not in token
+    assertThat(data.getModelVersion(), is(1)); // not in token
   }
 
   // ---- trackDuration --------------------------------------------------------
@@ -650,13 +669,37 @@ public class LDAIConfigTrackerImplTest {
     assertThat(dataCaptor.getValue().get("variationKey").stringValue(), is(VARIATION_KEY));
   }
 
+  // ---- model metadata inclusion --------------------------------------------
+
+  @Test
+  public void modelMetadataIncludedInPayloadWhenPresent() {
+    tracker.trackSuccess();
+    ArgumentCaptor<LDValue> dataCaptor = ArgumentCaptor.forClass(LDValue.class);
+    verify(client).trackMetric(eq("$ld:ai:generation:success"), any(), dataCaptor.capture(), anyDouble());
+    assertThat(dataCaptor.getValue().get("modelKey").stringValue(), is(MODEL_KEY));
+    assertThat(dataCaptor.getValue().get("modelVersion").intValue(), is(MODEL_VERSION));
+  }
+
+  @Test
+  public void blankModelKeyOmittedFromTrackDataAndPayload() {
+    LDAIConfigTrackerImpl t = makeTracker(VARIATION_KEY, "   ", MODEL_VERSION);
+    assertThat(t.getTrackData().getModelKey(), is(nullValue()));
+    assertThat(t.getTrackData().toLDValue().get("modelKey").isNull(), is(true));
+
+    t.trackSuccess();
+    ArgumentCaptor<LDValue> dataCaptor = ArgumentCaptor.forClass(LDValue.class);
+    verify(client).trackMetric(eq("$ld:ai:generation:success"), any(), dataCaptor.capture(), anyDouble());
+    assertThat(dataCaptor.getValue().get("modelKey").isNull(), is(true));
+    assertThat(dataCaptor.getValue().get("modelVersion").intValue(), is(MODEL_VERSION));
+  }
+
   // ---- graphKey inclusion ---------------------------------------------------
 
   @Test
   public void graphKeyIncludedInPayloadWhenSet() {
     LDAIConfigTrackerImpl t = new LDAIConfigTrackerImpl(
         client, RUN_ID, CONFIG_KEY, VARIATION_KEY, VERSION,
-        MODEL_NAME, PROVIDER_NAME, CONTEXT, "my-graph", logger);
+        MODEL_NAME, PROVIDER_NAME, MODEL_KEY, MODEL_VERSION, CONTEXT, "my-graph", logger);
     t.trackSuccess();
     ArgumentCaptor<LDValue> dataCaptor = ArgumentCaptor.forClass(LDValue.class);
     verify(client).trackMetric(eq("$ld:ai:generation:success"), any(), dataCaptor.capture(), anyDouble());
@@ -727,12 +770,12 @@ public class LDAIConfigTrackerImplTest {
   @Test(expected = NullPointerException.class)
   public void constructorRejectsNullClient() {
     new LDAIConfigTrackerImpl(null, RUN_ID, CONFIG_KEY, VARIATION_KEY, VERSION,
-        MODEL_NAME, PROVIDER_NAME, CONTEXT, null, logger);
+        MODEL_NAME, PROVIDER_NAME, MODEL_KEY, MODEL_VERSION, CONTEXT, null, logger);
   }
 
   @Test(expected = NullPointerException.class)
   public void constructorRejectsNullContext() {
     new LDAIConfigTrackerImpl(client, RUN_ID, CONFIG_KEY, VARIATION_KEY, VERSION,
-        MODEL_NAME, PROVIDER_NAME, null, null, logger);
+        MODEL_NAME, PROVIDER_NAME, MODEL_KEY, MODEL_VERSION, null, null, logger);
   }
 }

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
@@ -6,6 +6,7 @@ import static org.hamcrest.Matchers.containsString;
 import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
 import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.not;
 import static org.hamcrest.Matchers.notNullValue;
 import static org.hamcrest.Matchers.nullValue;
 import static org.mockito.ArgumentMatchers.any;
@@ -152,8 +153,16 @@ public class LDAIConfigTrackerImplTest {
 
   @Test
   public void resumptionTokenExcludesModelMetadata() {
+    String token = tracker.getResumptionToken();
+    String decodedJson = new String(
+        java.util.Base64.getUrlDecoder().decode(token), java.nio.charset.StandardCharsets.UTF_8);
+    assertThat(decodedJson, not(containsString("modelKey")));
+    assertThat(decodedJson, not(containsString("modelVersion")));
+
+    // Changing only model metadata must not change the encoded token, since decode() has no
+    // model fields to carry it and encode() never receives them.
     LDAIConfigTrackerImpl other = makeTracker(VARIATION_KEY, "different-model", 99);
-    assertThat(other.getResumptionToken(), is(tracker.getResumptionToken()));
+    assertThat(other.getResumptionToken(), is(token));
   }
 
   @Test

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
@@ -387,6 +387,7 @@ public class LDAIConfigTrackerImplTest {
         .put("runId", RUN_ID).put("configKey", CONFIG_KEY)
         .put("variationKey", VARIATION_KEY).put("version", VERSION)
         .put("modelName", MODEL_NAME).put("providerName", PROVIDER_NAME)
+        .put("modelKey", MODEL_KEY).put("modelVersion", MODEL_VERSION)
         .put("toolKey", "search")
         .build();
 
@@ -400,6 +401,7 @@ public class LDAIConfigTrackerImplTest {
         .put("runId", RUN_ID).put("configKey", CONFIG_KEY)
         .put("variationKey", VARIATION_KEY).put("version", VERSION)
         .put("modelName", MODEL_NAME).put("providerName", PROVIDER_NAME)
+        .put("modelKey", MODEL_KEY).put("modelVersion", MODEL_VERSION)
         .put("toolKey", "fetch")
         .build();
     verify(client, times(1)).trackMetric(
@@ -434,6 +436,7 @@ public class LDAIConfigTrackerImplTest {
         .put("runId", RUN_ID).put("configKey", CONFIG_KEY)
         .put("variationKey", VARIATION_KEY).put("version", VERSION)
         .put("modelName", MODEL_NAME).put("providerName", PROVIDER_NAME)
+        .put("modelKey", MODEL_KEY).put("modelVersion", MODEL_VERSION)
         .put("judgeConfigKey", "my-judge")
         .build();
 

--- a/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
+++ b/lib/sdk/server-ai/src/test/java/com/launchdarkly/sdk/server/ai/internal/LDAIConfigTrackerImplTest.java
@@ -685,10 +685,14 @@ public class LDAIConfigTrackerImplTest {
 
   @Test
   public void blankModelKeyOmittedFromTrackDataAndPayload() {
-    LDAIConfigTrackerImpl t = makeTracker(VARIATION_KEY, "   ", MODEL_VERSION);
-    assertThat(t.getTrackData().getModelKey(), is(nullValue()));
-    assertThat(t.getTrackData().toLDValue().get("modelKey").isNull(), is(true));
+    for (String blankModelKey : Arrays.asList(null, "", "   ")) {
+      LDAIConfigTrackerImpl blankTracker =
+          makeTracker(VARIATION_KEY, blankModelKey, MODEL_VERSION);
+      assertThat(blankTracker.getTrackData().getModelKey(), is(nullValue()));
+      assertThat(blankTracker.getTrackData().toLDValue().get("modelKey").isNull(), is(true));
+    }
 
+    LDAIConfigTrackerImpl t = makeTracker(VARIATION_KEY, "   ", MODEL_VERSION);
     t.trackSuccess();
     ArgumentCaptor<LDValue> dataCaptor = ArgumentCaptor.forClass(LDValue.class);
     verify(client).trackMetric(eq("$ld:ai:generation:success"), any(), dataCaptor.capture(), anyDouble());


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
**Requirements**

- [x] I have added test coverage for new or changed functionality
- [x] I have followed the repository's pull request submission guidelines
- [ ] I have validated my changes against all supported platform versions

**Related issues**

- [AIC-2977](https://launchdarkly.atlassian.net/browse/AIC-2977)
- Parent: [AIC-2849](https://launchdarkly.atlassian.net/browse/AIC-2849)

**Describe the solution you've provided**

Read `modelKey` and `modelVersion` from AI Config model payloads, expose them on the public model/tracking data types, and stamp them on every emitted tracker metric event. Model version defaults to `1`, null/empty/whitespace model keys are omitted, and the resumption-token format remains unchanged.

**Describe alternatives you've considered**

This mirrors the established JavaScript and .NET SDK implementations.

**Additional context**

Depends on AIC-2876 for the backend payload fields.

## Test plan

- [x] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 lib/sdk/server-ai/gradlew test -p lib/sdk/server-ai`
- [x] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 lib/sdk/server-ai/gradlew build -p lib/sdk/server-ai`
- [x] `JAVA_HOME=/usr/lib/jvm/java-17-openjdk-amd64 lib/sdk/server-ai/gradlew javadoc -p lib/sdk/server-ai`
- [ ] CI Java 8/11/17 matrix
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-dbeb9c1a-5b43-487b-824d-c0a2ab5f9a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-dbeb9c1a-5b43-487b-824d-c0a2ab5f9a0e"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>



[AIC-2977]: https://launchdarkly.atlassian.net/browse/AIC-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[AIC-2849]: https://launchdarkly.atlassian.net/browse/AIC-2849?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ