### PR TITLE
test: declare polling-gzip contract test capability

### DIFF
--- a/lib/sdk/server/contract-tests/service/src/main/java/sdktest/TestService.java
+++ b/lib/sdk/server/contract-tests/service/src/main/java/sdktest/TestService.java
@@ -42,6 +42,7 @@ public class TestService {
     "strongly-typed",
     "tags",
     "server-side-polling",
+    "polling-gzip",
     "fdv1-fallback",
     "instance-id"
   };


### PR DESCRIPTION
## What

Declares the `polling-gzip` contract-test capability for the Java server SDK, so the sdk-test-harness verifies `Accept-Encoding: gzip` on FDv2 polling requests.

Part of epic **SDK-950** (Polling Gzip Support) · ticket **SDK-2718**.

## Why this is capability-only

The Java SDK already requests and decompresses gzip on polling transparently via OkHttp's `BridgeInterceptor` (the SDK sets no `Accept-Encoding` header and adds no encoding interceptor), so no SDK code change is required — only the capability declaration in the contract-test service.

## Changes

- `lib/sdk/server/contract-tests/service/src/main/java/sdktest/TestService.java` — add `"polling-gzip"` to `CAPABILITIES`

## Verification

Ran the v3 harness polling suite locally against the built (`installDist`) test service with the capability enabled — all polling tests pass, including `polling/requests/method and headers` (the `Accept-Encoding: gzip` assertion). The mock returns HTTP 400 if the header is absent, so a green run confirms the header is sent and responses are decompressed end-to-end.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single string added to the contract-test capabilities array with no production SDK or runtime logic changes.
> 
> **Overview**
> Adds **`polling-gzip`** to the Java server contract-test service’s advertised capabilities in `TestService.java`, so the sdk-test-harness runs polling gzip checks (including **`Accept-Encoding: gzip`** on FDv2 polling) against this SDK.
> 
> This is a **capability-only** change: the harness gates those tests on the capability list returned from `GET /`; no production SDK behavior is modified in this PR.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75435d9c7bee63ebc75b13e4f62b43e26a3c9c5b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->