### PR TITLE
fix: Enable anonymous context redaction in server custom/migration events

### DIFF
--- a/lib/sdk/server/build.gradle
+++ b/lib/sdk/server/build.gradle
@@ -71,7 +71,7 @@ ext.versions = [
     "guava": "32.0.1-jre",
     "jackson": "2.11.2",
     "launchdarklyJavaSdkCommon": "2.3.0",
-    "launchdarklyJavaSdkInternal": "1.9.0",
+    "launchdarklyJavaSdkInternal": "1.9.1",
     "launchdarklyLogging": "1.1.0",
     "okhttp": "4.12.0", // specify this for the SDK build instead of relying on the transitive dependency from okhttp-eventsource
     "okhttpEventsource": "4.2.0",

--- a/lib/sdk/server/build.gradle
+++ b/lib/sdk/server/build.gradle
@@ -71,7 +71,7 @@ ext.versions = [
     "guava": "32.0.1-jre",
     "jackson": "2.11.2",
     "launchdarklyJavaSdkCommon": "2.3.0",
-    "launchdarklyJavaSdkInternal": "1.9.1",
+    "launchdarklyJavaSdkInternal": "1.10.0",
     "launchdarklyLogging": "1.1.0",
     "okhttp": "4.12.0", // specify this for the SDK build instead of relying on the transitive dependency from okhttp-eventsource
     "okhttpEventsource": "4.2.0",

--- a/lib/sdk/server/contract-tests/test-suppressions.txt
+++ b/lib/sdk/server/contract-tests/test-suppressions.txt
@@ -1,3 +1,1 @@
-events/custom events/single-kind anonymous context redacts all attributes
-events/custom events/multi-kind with anonymous context redacts attributes appropriately
-migrations/redacts anonymous context attributes
+

--- a/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/ComponentsImpl.java
+++ b/lib/sdk/server/src/main/java/com/launchdarkly/sdk/server/ComponentsImpl.java
@@ -247,7 +247,9 @@ abstract class ComponentsImpl {
           flushInterval.toMillis(),
           false,
           false,
-          privateAttributes);
+          privateAttributes,
+          false, // perContextSummarization: server-side SDKs summarize across contexts
+          true); // redactAnonymousAllEvents: server-side SDKs inline & redact custom/migration-op contexts
       return new DefaultEventProcessorWrapper(context, eventsConfig);
     }
     


### PR DESCRIPTION
## Summary

**Stacked on #194** (the `internal` change) — base branch is `mk/SDK-2732/redact-anonymous-custom-events`, so this PR shows only the **server-side consumption** diff. This is a preview of the follow-up that lands after `launchdarkly-java-sdk-internal` is released.

The internal PR adds the opt-in `redactAnonymousAllEvents` flag (default false). This PR has the server SDK consume it:

- `lib/sdk/server/build.gradle`: bump `launchdarklyJavaSdkInternal` `1.9.0` → `1.9.1` (the anticipated release containing the flag).
- `ComponentsImpl`: enable `redactAnonymousAllEvents: true` when constructing the server `EventsConfiguration`, so anonymous context attributes are redacted in custom and migration_op events.

## Effect
With this in place, the server contract tests `events/custom events/*anonymous*` and `migrations/redacts anonymous context attributes` pass (verified locally against sdk-test-harness `v2` @ `0317ec5`). Client/mobile SDKs are unaffected — they don't set the flag.

## Merge order / CI note
- Do **not** merge until #194 merges and `launchdarkly-java-sdk-internal 1.9.1` is released.
- Until then, CI here is red: it builds against released `internal 1.9.0`, which lacks the new constructor/flag (the version bump to 1.9.1 won't resolve yet). This PR exists to preview the diff and confirm the shape of the server change.

Jira: SDK-2732

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes event payload shaping for anonymous contexts in custom/migration events; behavior is intentional but affects privacy-sensitive analytics paths.
> 
> **Overview**
> Turns on **anonymous context attribute redaction** for server-side **custom** and **migration_op** events by wiring the new internal `EventsConfiguration` flags when the default event processor is built.
> 
> The server SDK bumps **`launchdarkly-java-sdk-internal`** to **1.10.0** and passes **`redactAnonymousAllEvents: true`** (with **`perContextSummarization: false`**) in `ComponentsImpl`, matching server-side summarization behavior. Contract-test **suppressions** for anonymous custom/migration scenarios are removed so those harness cases are expected to pass again.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4c3d0529f2e027cf376c8373f5037f04e3ee46e0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->